### PR TITLE
fix: add typing for `optimization.minimizers`

### DIFF
--- a/test/Optimization.js
+++ b/test/Optimization.js
@@ -65,6 +65,18 @@ test('minimizer plugin with args', () => {
   ]);
 });
 
+test('minimizer delete plugin', () => {
+  const optimization = new Optimization();
+
+  optimization.minimizer('foo').use(class Foo {});
+
+  expect(optimization.minimizers.has('foo')).toBe(true);
+
+  optimization.minimizers.delete('foo');
+
+  expect(optimization.minimizers.has('foo')).toBe(false);
+});
+
 test('minimizer plugin legacy syntax', () => {
   const optimization = new Optimization();
   expect(() => optimization.minimizer([new StringifyPlugin()])).toThrow(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -438,6 +438,7 @@ declare namespace Config {
   type SplitChunksObject = Exclude<RspackOptimization['splitChunks'], false>;
   class Optimization extends ChainedMap<Config> {
     minimizer(name: string): Config.Plugin<this, PluginInstance>;
+    minimizers: TypedChainedMap<this, Config.Plugin<this, PluginInstance>>;
     splitChunks: TypedChainedMap<this, SplitChunksObject> &
       ((value: SplitChunksObject | false) => this);
 

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -238,6 +238,8 @@ config
   .use(rspack.DefinePlugin)
   .tap((config) => [])
   .end()
+  .minimizers.delete('bar')
+  .end()
   .end()
   // plugins
   .plugin('foo')


### PR DESCRIPTION
This is useful for deleting the `SwcCssMinimizerRspackPlugin`.
