### PR TITLE
feat: support resolve.tsConfig

### DIFF
--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -37,6 +37,7 @@ module.exports = class extends ChainedMap {
       'unsafeCache',
       'preferRelative',
       'preferAbsolute',
+      'tsConfig',
     ]);
   }
 

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -185,3 +185,25 @@ test('plugin with args', () => {
     'beta',
   ]);
 });
+
+test('tsConfig string', () => {
+  const resolve = new Resolve();
+  resolve.tsConfig('./tsconfig.json').end();
+  expect(resolve.toConfig()).toStrictEqual({
+    tsConfig: './tsconfig.json',
+  });
+});
+
+test('tsConfig object', () => {
+  const resolve = new Resolve();
+  resolve.tsConfig({
+    configFile: './tsconfig.json',
+    references: 'auto',
+  })
+  expect(resolve.toConfig()).toStrictEqual({
+    tsConfig: {
+      configFile: './tsconfig.json',
+      references: 'auto',
+    },
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -388,6 +388,7 @@ declare namespace Config {
     preferAbsolute(value: RspackResolve['preferAbsolute']): this;
 
     plugin(name: string): Plugin<this, ResolvePlugin>;
+    tsConfig(value: RspackResolve['tsConfig']): this;
   }
 
   class RuleResolve<T = Config> extends Resolve<T> {

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -164,6 +164,12 @@ config
   .set('foo', false)
   .set('foo', ['asd'])
   .end()
+  .tsConfig('./tsconfig.json')
+  .delete('tsConfig')
+  .tsConfig({
+    configFile: './tsconfig.json',
+    references: 'auto',
+  })
   .modules.add('index.js')
   .end()
   .aliasFields.add('foo')


### PR DESCRIPTION
Currently rspack-chain does not support resolve.tsConfig, this pr will solve this problem
specific rspack document: 
https://rspack.dev/config/resolve#resolvetsconfig