### PR TITLE
fix: correct `values` return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,7 @@ declare namespace __Config {
     set<T extends keyof OptionsType>(key: T, value: OptionsType[T]): this;
     merge(obj: Partial<OptionsType>): this;
     entries(): OptionsType;
-    values<T extends keyof OptionsType>(): [OptionsType[T]][];
+    values<T extends keyof OptionsType>(): OptionsType[T][];
     when(
       condition: boolean,
       trueBrancher: (obj: this) => void,


### PR DESCRIPTION
`values()`后是一个数组，不是二维数组
类型测试用例有很多其他的问题，先不改了
<img width="840" alt="image" src="https://github.com/user-attachments/assets/a9cf68c0-3d3f-456b-a0a0-499491ecb005" />
