### PR TITLE
chore: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# This action will publish the package to npm and create a GitHub release.
+# Ref: https://docs.npmjs.com/trusted-publishers/
+name: Release
+
+on:
+  # Run `npm run bump` to bump the version and create a git tag.
+  push:
+    tags:
+      - "v*"
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack enable
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: empty
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: "true"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "style": "prettier --check .",
     "style:fix": "prettier --write .",
     "test": "rstest run",
-    "test:types": "tsc -p ./types/test/tsconfig.json"
+    "test:types": "tsc -p ./types/test/tsconfig.json",
+    "bump": "npx bumpp"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   ],
   "scripts": {
     "build": "rslib build",
+    "bump": "npx bumpp",
     "dev": "rslib build -w",
     "fix": "yarn lint:fix && yarn style:fix",
     "prepare": "pnpm build",
     "style": "prettier --check .",
     "style:fix": "prettier --write .",
     "test": "rstest run",
-    "test:types": "tsc -p ./types/test/tsconfig.json",
-    "bump": "npx bumpp"
+    "test:types": "tsc -p ./types/test/tsconfig.json"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers