### PR TITLE
fix: d.ts use export default for esm

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ import {
 } from '@rspack/core';
 import * as https from 'https';
 
-export = Config;
+export default Config;
 
 // The compiler type of Rspack / webpack are mismatch,
 // so we use a loose type here to allow using webpack plugins.

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -4,7 +4,7 @@
  */
 import * as rspack from '@rspack/core';
 
-import Config = require('rspack-chain');
+import Config from 'rspack-chain';
 
 type ResolvePlugin = Exclude<
   // @ts-expect-error Rspack does not supports resolve plugin


### PR DESCRIPTION
`rspack-chain`  is dual node package, the type file should use `export default Config;` instead `export = Config;`.