### PR TITLE
fix: add @rspack/core as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,13 @@
     "typescript": "^5.9.3",
     "webpack": "^5.103.0"
   },
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  },
   "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Summary

Add @rspack/core as optional peer dependency to ensure types are correct.