### PR TITLE
fix: update cache type to match Rspack v2

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,8 +88,7 @@ declare class Config extends __Config.ChainedMap<void> {
   experiments(value: RspackConfig['experiments']): this;
   amd(value: RspackConfig['amd']): this;
   bail(value: RspackConfig['bail']): this;
-  // Rspack only supports boolean cache
-  cache(value: any): this;
+  cache(value: RspackConfig['cache']): this;
   dependencies(value: RspackConfig['dependencies']): this;
   ignoreWarnings(value: RspackConfig['ignoreWarnings']): this;
   loader(value: RspackConfig['loader']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -375,7 +375,7 @@ config
   .bail(true)
   .cache(false)
   .cache({
-    type: 'filesystem',
+    type: 'persistent',
   })
   .devtool('hidden-source-map')
   .devtool(false)


### PR DESCRIPTION
Ref: https://github.com/web-infra-dev/rspack/pull/12705