### PR TITLE
feat: support display function name when config toString

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ export default class extends ChainedMap {
         // shorten long functions
         if (typeof value === 'function') {
           if (!verbose && value.toString().length > 100) {
-            return `function ${value.name}() { /* omitted long function */ }`;
+            return `function ${value.name || ''}() { /* omitted long function */ }`;
           }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ export default class extends ChainedMap {
         // shorten long functions
         if (typeof value === 'function') {
           if (!verbose && value.toString().length > 100) {
-            return `function () { /* omitted long function */ }`;
+            return `function ${value.name}() { /* omitted long function */ }`;
           }
         }
 

--- a/test/Config.js
+++ b/test/Config.js
@@ -668,6 +668,22 @@ test('toString for functions with custom expression', () => {
   );
 });
 
+test('toString for long function ', () => {
+  const fn = function foo () { 
+    // This is a long function that exceeds the default maxLength for expressions in javascript-stringify
+  };
+
+  const config = new Config();
+
+  config.externals(fn);
+
+  expect(config.toString().trim()).toMatchInlineSnapshot(`
+    "{
+      externals: function foo() { /* omitted long function */ }
+    }"
+  `);
+});
+
 test('toString with custom prefix', () => {
   const config = new Config();
 

--- a/test/Config.js
+++ b/test/Config.js
@@ -668,7 +668,7 @@ test('toString for functions with custom expression', () => {
   );
 });
 
-test('toString for long function ', () => {
+test('toString for long function', () => {
   const fn = function foo () { 
     // This is a long function that exceeds the default maxLength for expressions in javascript-stringify
   };
@@ -680,6 +680,22 @@ test('toString for long function ', () => {
   expect(config.toString().trim()).toMatchInlineSnapshot(`
     "{
       externals: function foo() { /* omitted long function */ }
+    }"
+  `);
+});
+
+test('toString for long anonymous function', () => {
+  const fn = () => () => { 
+    // This is a long function that exceeds the default maxLength for expressions in javascript-stringify
+  };
+
+  const config = new Config();
+
+  config.externals(fn());
+
+  expect(config.toString().trim()).toMatchInlineSnapshot(`
+    "{
+      externals: function () { /* omitted long function */ }
     }"
   `);
 });


### PR DESCRIPTION
support display function name when config toString.

before:
<img width="501" height="88" alt="image" src="https://github.com/user-attachments/assets/b843babe-a9f8-49da-8e71-3093080ebdcd" />

after:
<img width="529" height="83" alt="image" src="https://github.com/user-attachments/assets/d16f8ae8-2b04-4727-bec4-13585945a351" />

