### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "deepmerge": "^4.3.1",
     "javascript-stringify": "^2.1.0",
     "prettier": "^3.7.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "webpack": "^5.103.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.19.6
-        version: 0.19.6(typescript@5.9.3)
+        version: 0.19.6(typescript@6.0.2)
       '@rspack/core':
         specifier: 2.0.0-beta.7
         version: 2.0.0-beta.7(@swc/helpers@0.5.17)
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.7.3
         version: 3.7.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       webpack:
         specifier: ^5.103.0
         version: 5.104.1
@@ -703,8 +703,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -884,12 +884,12 @@ snapshots:
       core-js: 3.47.0
       jiti: 2.6.1
 
-  '@rslib/core@0.19.6(typescript@5.9.3)':
+  '@rslib/core@0.19.6(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.19.6(@rsbuild/core@1.7.3)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.19.6(@rsbuild/core@1.7.3)(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
@@ -1300,12 +1300,12 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  rsbuild-plugin-dts@0.19.6(@rsbuild/core@1.7.3)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.19.6(@rsbuild/core@1.7.3)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.7.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   safe-buffer@5.2.1: {}
 
@@ -1353,7 +1353,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.18.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
+    "declaration": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to ^6.0.2.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Validate the change with `pnpm build` and `pnpm test`.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2