### PR TITLE
feat!: switch to named RspackChain export

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ be `rspack.config.js` in the root of our project directory.
 
 ```js
 // Import the rspack-chain module. This module exports a single
-// constructor function for creating a configuration API.
-import Config from 'rspack-chain';
+// named constructor for creating a configuration API.
+import { RspackChain } from 'rspack-chain';
 
 // Instantiate the configuration with a new API
-const config = new Config();
+const config = new RspackChain();
 
 // Make configuration changes using the chain API.
 // Every API call tracks a change to the stored configuration.
@@ -109,9 +109,9 @@ and call `.toConfig()` prior to passing to rspack.
 
 ```js
 // rspack.core.js
-import Config from 'rspack-chain';
+import { RspackChain } from 'rspack-chain';
 
-const config = new Config();
+const config = new RspackChain();
 
 // Make configuration shared across targets
 // ...
@@ -333,14 +333,14 @@ devServer.set('hot', true);
 A shorthand method is chainable, so calling it will return the original
 instance, allowing you to continue to chain.
 
-### Config
+### RspackChain
 
 Create a new configuration object.
 
 ```js
-import Config from 'rspack-chain';
+import { RspackChain } from 'rspack-chain';
 
-const config = new Config();
+const config = new RspackChain();
 ```
 
 Moving to deeper points in the API will change the context of what you
@@ -355,10 +355,10 @@ low-level methods, please refer to their corresponding name in the
 [Rspack docs hierarchy](https://rspack.rs/config/).
 
 ```js
-Config: ChainedMap;
+RspackChain: ChainedMap;
 ```
 
-#### Config shorthand methods
+#### RspackChain shorthand methods
 
 ```js
 config
@@ -385,7 +385,7 @@ config
   .snapshot(snapshot);
 ```
 
-#### Config entryPoints
+#### RspackChain entryPoints
 
 ```js
 // Backed at config.entryPoints : ChainedMap
@@ -412,7 +412,7 @@ config.entryPoints
     .clear()
 ```
 
-#### Config output: shorthand methods
+#### RspackChain output: shorthand methods
 
 ```js
 config.output : ChainedMap
@@ -459,7 +459,7 @@ config.output
   .clean(clean)
 ```
 
-#### Config resolve: shorthand methods
+#### RspackChain resolve: shorthand methods
 
 ```js
 config.resolve : ChainedMap
@@ -475,7 +475,7 @@ config.resolve
   });
 ```
 
-#### Config resolve alias
+#### RspackChain resolve alias
 
 ```js
 config.resolve.alias : ChainedMap
@@ -487,7 +487,7 @@ config.resolve.alias
   .clear()
 ```
 
-#### Config resolve aliasFields
+#### RspackChain resolve aliasFields
 
 ```js
 config.resolve.aliasFields : ChainedSet
@@ -498,7 +498,7 @@ config.resolve.aliasFields
   .clear()
 ```
 
-#### Config resolve conditionNames
+#### RspackChain resolve conditionNames
 
 ```js
 config.resolve.conditionNames : ChainedSet
@@ -509,7 +509,7 @@ config.resolve.conditionNames
   .clear()
 ```
 
-#### Config resolve descriptionFields
+#### RspackChain resolve descriptionFields
 
 ```js
 config.resolve.descriptionFields : ChainedSet
@@ -520,7 +520,7 @@ config.resolve.descriptionFields
   .clear()
 ```
 
-#### Config resolve extensions
+#### RspackChain resolve extensions
 
 ```js
 config.resolve.extensions : ChainedSet
@@ -531,7 +531,7 @@ config.resolve.extensions
   .clear()
 ```
 
-#### Config resolve extensionAlias
+#### RspackChain resolve extensionAlias
 
 ```js
 config.resolve.extensionAlias : ChainedMap
@@ -541,7 +541,7 @@ config.resolve.extensionAlias
   .clear()
 ```
 
-#### Config resolve mainFields
+#### RspackChain resolve mainFields
 
 ```js
 config.resolve.mainFields : ChainedSet
@@ -552,7 +552,7 @@ config.resolve.mainFields
   .clear()
 ```
 
-#### Config resolve mainFiles
+#### RspackChain resolve mainFiles
 
 ```js
 config.resolve.mainFiles : ChainedSet
@@ -563,7 +563,7 @@ config.resolve.mainFiles
   .clear()
 ```
 
-#### Config resolve exportsFields
+#### RspackChain resolve exportsFields
 
 ```js
 config.resolve.exportsFields : ChainedSet
@@ -574,7 +574,7 @@ config.resolve.exportsFields
   .clear()
 ```
 
-#### Config resolve importsFields
+#### RspackChain resolve importsFields
 
 ```js
 config.resolve.importsFields : ChainedSet
@@ -585,7 +585,7 @@ config.resolve.importsFields
   .clear()
 ```
 
-#### Config resolve restrictions
+#### RspackChain resolve restrictions
 
 ```js
 config.resolve.restrictions : ChainedSet
@@ -596,7 +596,7 @@ config.resolve.restrictions
   .clear()
 ```
 
-#### Config resolve roots
+#### RspackChain resolve roots
 
 ```js
 config.resolve.roots : ChainedSet
@@ -607,7 +607,7 @@ config.resolve.roots
   .clear()
 ```
 
-#### Config resolve modules
+#### RspackChain resolve modules
 
 ```js
 config.resolve.modules : ChainedSet
@@ -618,7 +618,7 @@ config.resolve.modules
   .clear()
 ```
 
-#### Config resolve fallback
+#### RspackChain resolve fallback
 
 ```js
 config.resolve.fallback : ChainedMap
@@ -630,7 +630,7 @@ config.resolve.fallback
   .clear()
 ```
 
-#### Config resolve byDependency
+#### RspackChain resolve byDependency
 
 ```js
 config.resolve.byDependency : ChainedMap
@@ -642,12 +642,12 @@ config.resolve.byDependency
   .clear()
 ```
 
-#### Config resolveLoader
+#### RspackChain resolveLoader
 
 The API for `config.resolveLoader` is identical to `config.resolve` with
 the following additions:
 
-#### Config resolveLoader modules
+#### RspackChain resolveLoader modules
 
 ```js
 config.resolveLoader.modules : ChainedSet
@@ -658,7 +658,7 @@ config.resolveLoader.modules
   .clear()
 ```
 
-#### Config resolveLoader moduleExtensions
+#### RspackChain resolveLoader moduleExtensions
 
 ```js
 config.resolveLoader.moduleExtensions : ChainedSet
@@ -669,7 +669,7 @@ config.resolveLoader.moduleExtensions
   .clear()
 ```
 
-#### Config resolveLoader packageMains
+#### RspackChain resolveLoader packageMains
 
 ```js
 config.resolveLoader.packageMains : ChainedSet
@@ -680,7 +680,7 @@ config.resolveLoader.packageMains
   .clear()
 ```
 
-#### Config performance: shorthand methods
+#### RspackChain performance: shorthand methods
 
 ```js
 config.performance : ChainedValueMap
@@ -716,7 +716,7 @@ config.optimization
   .realContentHash(realContentHash)
 ```
 
-#### Config optimization minimizers
+#### RspackChain optimization minimizers
 
 ```js
 // Backed at config.optimization.minimizers
@@ -724,7 +724,7 @@ config.optimization
   .minimizer(name) : ChainedMap
 ```
 
-#### Config optimization minimizers: adding
+#### RspackChain optimization minimizers: adding
 
 _NOTE: Do not use `new` to create the minimizer plugin, as this will be done for you._
 
@@ -750,7 +750,7 @@ config.optimization
   ]);
 ```
 
-#### Config optimization minimizers: modify arguments
+#### RspackChain optimization minimizers: modify arguments
 
 ```js
 config.optimization.minimizer(name).tap((args) => newArgs);
@@ -761,19 +761,19 @@ config.optimization
   .tap((args) => [...args, { cssProcessorOptions: { safe: false } }]);
 ```
 
-#### Config optimization minimizers: modify instantiation
+#### RspackChain optimization minimizers: modify instantiation
 
 ```js
 config.optimization.minimizer(name).init((Plugin, args) => new Plugin(...args));
 ```
 
-#### Config optimization minimizers: removing
+#### RspackChain optimization minimizers: removing
 
 ```js
 config.optimization.minimizers.delete(name);
 ```
 
-#### Config optimization splitChunks
+#### RspackChain optimization splitChunks
 
 ```js
 config.optimization.splitChunks : ChainedValueMap
@@ -788,14 +788,14 @@ config.optimization
   .clear()
 ```
 
-#### Config plugins
+#### RspackChain plugins
 
 ```js
 // Backed at config.plugins
 config.plugin(name) : ChainedMap
 ```
 
-#### Config plugins: adding
+#### RspackChain plugins: adding
 
 _NOTE: Do not use `new` to create the plugin, as this will be done for you._
 
@@ -818,7 +818,7 @@ config.plugin('env').use(EnvironmentPlugin, [{ VAR: false }]);
 config.plugin('custom').use(require.resolve('my-plugin'), [{ answer: 42 }]);
 ```
 
-#### Config plugins: modify arguments
+#### RspackChain plugins: modify arguments
 
 ```js
 config.plugin(name).tap((args) => newArgs);
@@ -827,19 +827,19 @@ config.plugin(name).tap((args) => newArgs);
 config.plugin('env').tap((args) => [...args, 'SECRET_KEY']);
 ```
 
-#### Config plugins: modify instantiation
+#### RspackChain plugins: modify instantiation
 
 ```js
 config.plugin(name).init((Plugin, args) => new Plugin(...args));
 ```
 
-#### Config plugins: removing
+#### RspackChain plugins: removing
 
 ```js
 config.plugins.delete(name);
 ```
 
-#### Config plugins: ordering before
+#### RspackChain plugins: ordering before
 
 Specify that the current `plugin` context should operate before another named
 `plugin`. You cannot use both `.before()` and `.after()` on the same plugin.
@@ -858,7 +858,7 @@ config
   .before('html-template');
 ```
 
-#### Config plugins: ordering after
+#### RspackChain plugins: ordering after
 
 Specify that the current `plugin` context should operate after another named
 `plugin`. You cannot use both `.before()` and `.after()` on the same plugin.
@@ -877,7 +877,7 @@ config
   .use(ScriptExtRspackPlugin);
 ```
 
-#### Config node
+#### RspackChain node
 
 ```js
 config.node : ChainedValueMap
@@ -888,13 +888,13 @@ config.node(false)
   .set('__filename', 'mock');
 ```
 
-#### Config devServer
+#### RspackChain devServer
 
 ```js
 config.devServer : ChainedMap
 ```
 
-#### Config devServer allowedHosts
+#### RspackChain devServer allowedHosts
 
 ```js
 config.devServer.allowedHosts : ChainedSet
@@ -905,7 +905,7 @@ config.devServer.allowedHosts
   .clear()
 ```
 
-#### Config devServer: shorthand methods
+#### RspackChain devServer: shorthand methods
 
 ```js
 config.devServer
@@ -961,13 +961,13 @@ config.devServer
   .writeToDisk(writeToDisk);
 ```
 
-#### Config module
+#### RspackChain module
 
 ```js
 config.module : ChainedMap
 ```
 
-#### Config module: shorthand methods
+#### RspackChain module: shorthand methods
 
 ```js
 config.module : ChainedMap
@@ -975,7 +975,7 @@ config.module : ChainedMap
 config.module.noParse(noParse)
 ```
 
-#### Config module rules: shorthand methods
+#### RspackChain module rules: shorthand methods
 
 ```js
 config.module.rules : ChainedMap
@@ -988,7 +988,7 @@ config.module
     .enforce(preOrPost)
 ```
 
-#### Config module rules uses (loaders): creating
+#### RspackChain module rules uses (loaders): creating
 
 ```js
 config.module.rules{}.uses : ChainedMap
@@ -1008,7 +1008,7 @@ config.module
       .options({ presets: ['@babel/preset-env'] });
 ```
 
-#### Config module rules uses (loaders): modifying options
+#### RspackChain module rules uses (loaders): modifying options
 
 ```js
 config.module
@@ -1028,7 +1028,7 @@ config.module
   );
 ```
 
-#### Config module rules nested rules:
+#### RspackChain module rules nested rules:
 
 ```js
 config.module.rules{}.rules : ChainedMap<Rule>
@@ -1051,7 +1051,7 @@ config.module
         .loader('postcss-loader')
 ```
 
-#### Config module rules nested rules: ordering before
+#### RspackChain module rules nested rules: ordering before
 
 Specify that the current `rule` context should operate before another named
 `rule`. You cannot use both `.before()` and `.after()` on the same `rule`.
@@ -1084,7 +1084,7 @@ config.module
         .loader('css-loader')
 ```
 
-#### Config module rules nested rules: ordering after
+#### RspackChain module rules nested rules: ordering after
 
 Specify that the current `rule` context should operate after another named
 `rule`. You cannot use both `.before()` and `.after()` on the same `rule`.
@@ -1117,7 +1117,7 @@ config.module
         .loader('css-loader')
 ```
 
-#### Config module rules oneOfs (conditional rules):
+#### RspackChain module rules oneOfs (conditional rules):
 
 ```js
 config.module.rules{}.oneOfs : ChainedMap<Rule>
@@ -1142,7 +1142,7 @@ config.module
         .loader('file-loader')
 ```
 
-#### Config module rules oneOfs (conditional rules): ordering before
+#### RspackChain module rules oneOfs (conditional rules): ordering before
 
 Specify that the current `oneOf` context should operate before another named
 `oneOf`. You cannot use both `.before()` and `.after()` on the same `oneOf`.
@@ -1167,7 +1167,7 @@ config.module
   .loader('sass-vars-to-js-loader');
 ```
 
-#### Config module rules oneOfs (conditional rules): ordering after
+#### RspackChain module rules oneOfs (conditional rules): ordering after
 
 Specify that the current `oneOf` context should operate after another named
 `oneOf`. You cannot use both `.before()` and `.after()` on the same `oneOf`.
@@ -1198,12 +1198,12 @@ config.module
   .loader('sass-vars-to-js-loader');
 ```
 
-#### Config module rules resolve
+#### RspackChain module rules resolve
 
 Specify a resolve configuration to be merged over the default `config.resolve`
 for modules that match the rule.
 
-See "Config resolve" sections above for full syntax.
+See "RspackChain resolve" sections above for full syntax.
 
 ```js
 config.module.rule(name).resolve;
@@ -1218,7 +1218,7 @@ config.module
 
 ---
 
-### Merging Config
+### Merging RspackChain
 
 rspack-chain supports merging in an object to the configuration instance which
 matches a layout similar to how the rspack-chain schema is laid out.
@@ -1532,11 +1532,11 @@ config.toString();
 The resulting string will use the absolute path returned by
 `require.resolve('my-plugin')` when constructing the plugin.
 
-You can also call `toString` as a static method on `Config` in order to
+You can also call `toString` as a static method on `RspackChain` in order to
 modify the configuration object prior to stringifying.
 
 ```js
-Config.toString({
+RspackChain.toString({
   ...config.toConfig(),
   module: {
     defaultRules: [

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ const toEntryObject = (entryPoints) => {
   return formattedEntry;
 };
 
-export default class extends ChainedMap {
+class RspackChain extends ChainedMap {
   constructor() {
     super();
     this.entryPoints = new ChainedMap(this);
@@ -216,3 +216,5 @@ export default class extends ChainedMap {
     return super.merge(obj, [...omit, ...omissions, 'entry', 'plugin']);
   }
 }
+
+export { RspackChain };

--- a/test/Config.js
+++ b/test/Config.js
@@ -1,6 +1,6 @@
 import { EnvironmentPlugin } from '@rspack/core';
 import { stringify } from 'javascript-stringify';
-import Config from '../src';
+import { RspackChain } from '../src';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -18,7 +18,7 @@ class StringifyPlugin {
 }
 
 test('is ChainedMap', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.set('a', 'alpha');
 
@@ -26,7 +26,7 @@ test('is ChainedMap', () => {
 });
 
 test('shorthand methods', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const obj = {};
 
   config.shorthands.forEach((method) => {
@@ -38,7 +38,7 @@ test('shorthand methods', () => {
 });
 
 test('node is object', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.node
     .set('__dirname', 'mock')
     .set('__filename', 'mock')
@@ -52,7 +52,7 @@ test('node is object', () => {
 });
 
 test('node is value', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.node(false);
 
   expect(instance).toBe(config);
@@ -60,7 +60,7 @@ test('node is value', () => {
 });
 
 test('performance is false', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.performance(false);
 
   expect(instance).toBe(config);
@@ -68,7 +68,7 @@ test('performance is false', () => {
 });
 
 test('bail', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.bail(false);
 
   expect(instance.toConfig()).toStrictEqual({
@@ -77,7 +77,7 @@ test('bail', () => {
 });
 
 test('cache', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   const instanceBoolean = config.cache(false);
   expect(instanceBoolean.toConfig()).toStrictEqual({
@@ -102,7 +102,7 @@ test('cache', () => {
 });
 
 test('name', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.name('aaa');
   expect(instance.toConfig()).toStrictEqual({
     name: 'aaa',
@@ -110,7 +110,7 @@ test('name', () => {
 });
 
 test('entry', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.entry('index').add('babel-polyfill').add('src/index.js');
 
@@ -125,7 +125,7 @@ test('entry', () => {
 });
 
 test('entry description object', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config
     .entry('index')
@@ -168,7 +168,7 @@ test('entry description object', () => {
 });
 
 test('plugin empty', () => {
-  const config = new Config();
+  const config = new RspackChain();
   const instance = config.plugin('stringify').use(StringifyPlugin).end();
 
   expect(instance).toBe(config);
@@ -177,7 +177,7 @@ test('plugin empty', () => {
 });
 
 test('plugin with args', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.plugin('stringify').use(StringifyPlugin, ['alpha', 'beta']);
 
@@ -189,13 +189,13 @@ test('plugin with args', () => {
 });
 
 test('toConfig empty', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   expect(config.toConfig()).toStrictEqual({});
 });
 
 test('toConfig with values', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.output
     .path('build')
@@ -279,7 +279,7 @@ test('toConfig with values', () => {
 });
 
 test('merge empty', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   const obj = {
     mode: 'development',
@@ -323,7 +323,7 @@ test('merge empty', () => {
 });
 
 test('merge with values', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.output
     .path('build')
@@ -377,7 +377,7 @@ test('merge with values', () => {
 });
 
 test('merge with omit', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.output
     .path('build')
@@ -431,7 +431,7 @@ test('merge with omit', () => {
 });
 
 test('lazyCompilation - boolean', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.lazyCompilation(true);
 
@@ -441,7 +441,7 @@ test('lazyCompilation - boolean', () => {
 });
 
 test('lazyCompilation - object', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.lazyCompilation({
     imports: true,
@@ -461,7 +461,7 @@ test('lazyCompilation - object', () => {
 });
 
 test('toString', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.module.rule('alpha').oneOf('beta').use('babel').loader('babel-loader');
 
@@ -587,7 +587,7 @@ test('toString for functions with custom expression', () => {
   const fn = function foo() {};
   fn.__expression = `require('foo')`;
 
-  const config = new Config();
+  const config = new RspackChain();
 
   config.module.rule('alpha').include.add(fn);
 
@@ -614,7 +614,7 @@ test('toString for long function', () => {
     // This is a long function that exceeds the default maxLength for expressions in javascript-stringify
   };
 
-  const config = new Config();
+  const config = new RspackChain();
 
   config.externals(fn);
 
@@ -630,7 +630,7 @@ test('toString for long anonymous function', () => {
     // This is a long function that exceeds the default maxLength for expressions in javascript-stringify
   };
 
-  const config = new Config();
+  const config = new RspackChain();
 
   config.externals(fn());
 
@@ -642,7 +642,7 @@ test('toString for long anonymous function', () => {
 });
 
 test('toString with custom prefix', () => {
-  const config = new Config();
+  const config = new RspackChain();
 
   config.plugin('foo').use(class TestPlugin {});
 
@@ -658,8 +658,8 @@ test('toString with custom prefix', () => {
   );
 });
 
-test('static Config.toString', () => {
-  const config = new Config();
+test('static RspackChain.toString', () => {
+  const config = new RspackChain();
   const sass = {
     __expression: `require('sass')`,
     render() {},
@@ -668,7 +668,7 @@ test('static Config.toString', () => {
   config.plugin('foo').use(class TestPlugin {});
 
   expect(
-    Config.toString(
+    RspackChain.toString(
       Object.assign(config.toConfig(), {
         module: {
           defaultRules: [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,5 @@
-import {
-  Configuration,
-  Compiler,
-  RuleSetRule,
-  ResolveOptions,
-} from '@rspack/core';
-import * as https from 'https';
-
-export default Config;
+import { Configuration, Compiler, RuleSetRule } from '@rspack/core';
+import * as https from 'node:https';
 
 // The compiler type of Rspack / webpack are mismatch,
 // so we use a loose type here to allow using webpack plugins.
@@ -60,24 +53,24 @@ declare namespace __Config {
 }
 
 type RspackConfig = Required<Configuration>;
-declare class Config extends __Config.ChainedMap<void> {
-  entryPoints: Config.TypedChainedMap<
-    Config,
-    { [key: string]: Config.EntryPoint }
+export declare class RspackChain extends __Config.ChainedMap<void> {
+  entryPoints: RspackChain.TypedChainedMap<
+    RspackChain,
+    { [key: string]: RspackChain.EntryPoint }
   >;
-  output: Config.Output;
-  module: Config.Module;
-  node: Config.ChainedMap<this> & ((value: boolean) => this);
-  optimization: Config.Optimization;
-  performance: Config.Performance & ((value: boolean) => this);
-  plugins: Config.Plugins<this, PluginInstance>;
-  resolve: Config.Resolve;
-  resolveLoader: Config.ResolveLoader;
-  devServer: Config.DevServer;
+  output: RspackChain.Output;
+  module: RspackChain.Module;
+  node: RspackChain.ChainedMap<this> & ((value: boolean) => this);
+  optimization: RspackChain.Optimization;
+  performance: RspackChain.Performance & ((value: boolean) => this);
+  plugins: RspackChain.Plugins<this, PluginInstance>;
+  resolve: RspackChain.Resolve;
+  resolveLoader: RspackChain.ResolveLoader;
+  devServer: RspackChain.DevServer;
 
   context(value: RspackConfig['context']): this;
   mode(value: RspackConfig['mode']): this;
-  devtool(value: Config.DevTool): this;
+  devtool(value: RspackChain.DevTool): this;
   target(value: RspackConfig['target']): this;
   watch(value: RspackConfig['watch']): this;
   watchOptions(value: RspackConfig['watchOptions']): this;
@@ -97,8 +90,8 @@ declare class Config extends __Config.ChainedMap<void> {
   snapshot(value: RspackConfig['snapshot']): this;
   lazyCompilation(value: RspackConfig['lazyCompilation']): this;
 
-  entry(name: string): Config.EntryPoint;
-  plugin(name: string): Config.Plugin<this, PluginInstance>;
+  entry(name: string): RspackChain.EntryPoint;
+  plugin(name: string): RspackChain.Plugin<this, PluginInstance>;
 
   toConfig(): Configuration;
 
@@ -114,7 +107,7 @@ declare class Config extends __Config.ChainedMap<void> {
   ): string;
 }
 
-declare namespace Config {
+export declare namespace RspackChain {
   class Chained<Parent> extends __Config.Chained<Parent> {}
   class TypedChainedMap<Parent, OptionsType> extends __Config.TypedChainedMap<
     Parent,
@@ -169,11 +162,11 @@ declare namespace Config {
     string | string[] | Function
   >[string];
 
-  class EntryPoint extends TypedChainedSet<Config, RspackEntryObject> {}
+  class EntryPoint extends TypedChainedSet<RspackChain, RspackEntryObject> {}
 
   type RspackModule = Required<NonNullable<Configuration['module']>>;
 
-  class Module extends ChainedMap<Config> {
+  class Module extends ChainedMap<RspackChain> {
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
     generator: ChainedMap<this>;
     parser: ChainedMap<this>;
@@ -183,7 +176,7 @@ declare namespace Config {
 
   type RspackOutput = Required<NonNullable<Configuration['output']>>;
 
-  class Output extends ChainedMap<Config> {
+  class Output extends ChainedMap<RspackChain> {
     assetModuleFilename(value: RspackOutput['assetModuleFilename']): this;
     bundlerInfo(value: RspackOutput['bundlerInfo']): this;
     chunkFilename(value: RspackOutput['chunkFilename']): this;
@@ -242,7 +235,7 @@ declare namespace Config {
   }
 
   // await for @types/webpack-dev-server update do v4 to remove all any
-  class DevServer extends ChainedMap<Config> {
+  class DevServer extends ChainedMap<RspackChain> {
     allowedHosts: TypedChainedSet<this, string>;
     after(value: (app: any, server: any, compiler: Compiler) => void): this;
     before(value: (app: any, server: any, compiler: Compiler) => void): this;
@@ -326,7 +319,7 @@ declare namespace Config {
     Required<NonNullable<Configuration['performance']>>,
     false
   >;
-  class Performance extends ChainedMap<Config> {
+  class Performance extends ChainedMap<RspackChain> {
     hints(value: RspackPerformance['hints']): this;
     maxEntrypointSize(value: RspackPerformance['maxEntrypointSize']): this;
     maxAssetSize(value: RspackPerformance['maxAssetSize']): this;
@@ -334,7 +327,7 @@ declare namespace Config {
   }
 
   type RspackResolve = Required<NonNullable<Configuration['resolve']>>;
-  class Resolve<T = Config> extends ChainedMap<T> {
+  class Resolve<T = RspackChain> extends ChainedMap<T> {
     alias: TypedChainedMap<this, { [key: string]: string | false | string[] }>;
     aliasFields: TypedChainedSet<this, RspackResolve['aliasFields'][number]>;
     conditionNames: TypedChainedSet<
@@ -373,7 +366,7 @@ declare namespace Config {
     tsConfig(value: RspackResolve['tsConfig']): this;
   }
 
-  class RuleResolve<T = Config> extends Resolve<T> {
+  class RuleResolve<T = RspackChain> extends Resolve<T> {
     fullySpecified(value: boolean): this;
   }
 
@@ -422,9 +415,9 @@ declare namespace Config {
     NonNullable<Configuration['optimization']>
   >;
   type SplitChunksObject = Exclude<RspackOptimization['splitChunks'], false>;
-  class Optimization extends ChainedMap<Config> {
-    minimizer(name: string): Config.Plugin<this, PluginInstance>;
-    minimizers: TypedChainedMap<this, Config.Plugin<this, PluginInstance>>;
+  class Optimization extends ChainedMap<RspackChain> {
+    minimizer(name: string): RspackChain.Plugin<this, PluginInstance>;
+    minimizers: TypedChainedMap<this, RspackChain.Plugin<this, PluginInstance>>;
     splitChunks: TypedChainedMap<this, SplitChunksObject> &
       ((value: SplitChunksObject | false) => this);
 

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -1,13 +1,13 @@
 /**
  * Notes: The order structure of the type check follows the order
- * of this document: https://github.com/neutrinojs/rspack-chain#config
+ * of this document: https://github.com/neutrinojs/rspack-chain#rspackchain
  */
 import * as rspack from '@rspack/core';
-import Config from 'rspack-chain';
+import { RspackChain } from 'rspack-chain';
 
 function expectType<T>(value: T) {}
 
-const config = new Config();
+const config = new RspackChain();
 
 config
   // entry
@@ -34,8 +34,7 @@ config
   .entryPoints.delete('main')
   .end()
   // output
-  .output
-  .bundlerInfo({
+  .output.bundlerInfo({
     force: false,
   })
   .chunkFilename('')
@@ -394,17 +393,19 @@ const entryPoints = config.entryPoints;
 expectType<typeof entryPoints>(entryPoints.clear());
 expectType<typeof entryPoints>(entryPoints.delete('key'));
 expectType<boolean>(entryPoints.has('key'));
-expectType<Config.EntryPoint>(entryPoints.get('key'));
-expectType<Config.EntryPoint>(
-  entryPoints.getOrCompute('key', () => new Config.EntryPoint()),
+expectType<RspackChain.EntryPoint>(entryPoints.get('key'));
+expectType<RspackChain.EntryPoint>(
+  entryPoints.getOrCompute('key', () => new RspackChain.EntryPoint()),
 );
-expectType<typeof entryPoints>(entryPoints.set('key', new Config.EntryPoint()));
+expectType<typeof entryPoints>(
+  entryPoints.set('key', new RspackChain.EntryPoint()),
+);
 expectType<typeof entryPoints>(
   entryPoints.merge({
-    key: new Config.EntryPoint(),
+    key: new RspackChain.EntryPoint(),
   }),
 );
-expectType<Record<string, Config.EntryPoint>>(entryPoints.entries());
+expectType<Record<string, RspackChain.EntryPoint>>(entryPoints.entries());
 expectType<typeof entryPoints>(
   entryPoints.when(
     true,


### PR DESCRIPTION
## Summary
- replace the package default export with a named `RspackChain` export so the runtime entry point and public types expose the same API shape
- update the README examples plus runtime and type tests to use `import { RspackChain } from 'rspack-chain'`

## Testing
- `pnpm test`
- `pnpm test:types`
- `pnpm build`

## Related Links
- None