### PR TITLE
fix: align devServer options with rspack v2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,21 +898,11 @@ config.node(false)
 config.devServer : ChainedMap
 ```
 
-#### devServer allowedHosts
-
-```js
-config.devServer.allowedHosts : ChainedSet
-
-config.devServer.allowedHosts
-  .add(value)
-  .prepend(value)
-  .clear()
-```
-
 #### devServer: shorthand methods
 
 ```js
 config.devServer
+  .allowedHosts(allowedHosts)
   .app(app)
   .client(client)
   .compress(compress)

--- a/README.md
+++ b/README.md
@@ -913,56 +913,26 @@ config.devServer.allowedHosts
 
 ```js
 config.devServer
-  .after(after)
-  .before(before)
-  .bonjour(bonjour)
-  .clientLogLevel(clientLogLevel)
+  .app(app)
+  .client(client)
   .compress(compress)
-  .contentBase(contentBase)
-  .contentBasePublicPath(contentBasePublicPath)
-  .disableHostCheck(disableHostCheck)
-  .filename(filename)
+  .devMiddleware(devMiddleware)
   .headers(headers)
   .historyApiFallback(historyApiFallback)
   .host(host)
   .hot(hot)
-  .hotOnly(hotOnly)
-  .http2(http2)
-  .https(https)
-  .index(index)
-  .injectClient(injectClient)
-  .injectHot(injectHot)
-  .inline(inline)
-  .lazy(lazy)
   .liveReload(liveReload)
-  .mimeTypes(mimeTypes)
-  .noInfo(noInfo)
+  .ipc(ipc)
   .onListening(onListening)
   .open(open)
-  .openPage(openPage)
-  .overlay(overlay)
-  .pfx(pfx)
-  .pfxPassphrase(pfxPassphrase)
   .port(port)
-  .progress(progress)
   .proxy(proxy)
-  .public(public)
-  .publicPath(publicPath)
-  .quiet(quiet)
-  .serveIndex(serveIndex)
-  .setup(setup)
-  .socket(socket)
-  .sockHost(sockHost)
-  .sockPath(sockPath)
-  .sockPort(sockPort)
-  .staticOptions(staticOptions)
-  .stats(stats)
-  .stdin(stdin)
-  .transportMode(transportMode)
-  .useLocalIp(useLocalIp)
-  .watchContentBase(watchContentBase)
-  .watchOptions(watchOptions)
-  .writeToDisk(writeToDisk);
+  .server(server)
+  .setupExitSignals(setupExitSignals)
+  .setupMiddlewares(setupMiddlewares)
+  .static(static)
+  .watchFiles(watchFiles)
+  .webSocketServer(webSocketServer);
 ```
 
 #### module
@@ -1271,26 +1241,27 @@ config.merge({
   devServer: {
     [key]: value,
 
-    clientLogLevel,
+    allowedHosts,
+    app,
+    client,
     compress,
-    contentBase,
-    filename,
+    devMiddleware,
     headers,
     historyApiFallback,
     host,
     hot,
-    hotOnly,
-    https,
-    inline,
-    lazy,
-    noInfo,
-    overlay,
+    ipc,
+    liveReload,
+    onListening,
+    open,
     port,
     proxy,
-    quiet,
-    setup,
-    stats,
-    watchContentBase,
+    server,
+    setupExitSignals,
+    setupMiddlewares,
+    static,
+    watchFiles,
+    webSocketServer,
   },
 
   node: {

--- a/src/DevServer.js
+++ b/src/DevServer.js
@@ -8,56 +8,26 @@ export default class extends ChainedMap {
     this.allowedHosts = new ChainedSet(this);
 
     this.extend([
-      'after',
-      'before',
-      'bonjour',
-      'clientLogLevel',
+      'app',
+      'client',
       'compress',
-      'contentBase',
-      'contentBasePublicPath',
-      'disableHostCheck',
-      'filename',
+      'devMiddleware',
       'headers',
-      'historyApiFallback',
       'host',
+      'historyApiFallback',
       'hot',
-      'hotOnly',
-      'http2',
-      'https',
-      'index',
-      'injectClient',
-      'injectHot',
-      'inline',
-      'lazy',
+      'ipc',
       'liveReload',
-      'mimeTypes',
-      'noInfo',
       'onListening',
       'open',
-      'openPage',
-      'overlay',
-      'pfx',
-      'pfxPassphrase',
       'port',
       'proxy',
-      'progress',
-      'public',
-      'publicPath',
-      'quiet',
-      'serveIndex',
-      'setup',
-      'socket',
-      'sockHost',
-      'sockPath',
-      'sockPort',
-      'staticOptions',
-      'stats',
-      'stdin',
-      'transportMode',
-      'useLocalIp',
-      'watchContentBase',
-      'watchOptions',
-      'writeToDisk',
+      'server',
+      'setupExitSignals',
+      'setupMiddlewares',
+      'static',
+      'watchFiles',
+      'webSocketServer',
     ]);
   }
 
@@ -70,7 +40,15 @@ export default class extends ChainedMap {
 
   merge(obj, omit = []) {
     if (!omit.includes('allowedHosts') && 'allowedHosts' in obj) {
-      this.allowedHosts.merge(obj.allowedHosts);
+      const { allowedHosts } = obj;
+
+      if (Array.isArray(allowedHosts)) {
+        this.delete('allowedHosts');
+        this.allowedHosts.merge(allowedHosts);
+      } else {
+        this.allowedHosts.clear();
+        this.set('allowedHosts', allowedHosts);
+      }
     }
 
     return super.merge(obj, ['allowedHosts']);

--- a/src/DevServer.js
+++ b/src/DevServer.js
@@ -31,6 +31,34 @@ export default class extends ChainedMap {
     ]);
   }
 
+  clear() {
+    this.allowedHosts.clear();
+    return super.clear();
+  }
+
+  delete(key) {
+    if (key === 'allowedHosts') {
+      this.allowedHosts.clear();
+    }
+
+    return super.delete(key);
+  }
+
+  set(key, value) {
+    if (key !== 'allowedHosts') {
+      return super.set(key, value);
+    }
+
+    this.allowedHosts.clear();
+
+    if (Array.isArray(value)) {
+      this.allowedHosts.merge(value);
+      return super.delete(key);
+    }
+
+    return super.set(key, value);
+  }
+
   toConfig() {
     return this.clean({
       allowedHosts: this.allowedHosts.values(),
@@ -42,15 +70,11 @@ export default class extends ChainedMap {
     if (!omit.includes('allowedHosts') && 'allowedHosts' in obj) {
       const { allowedHosts } = obj;
 
-      if (Array.isArray(allowedHosts)) {
-        this.delete('allowedHosts');
-        this.allowedHosts.merge(allowedHosts);
-      } else {
-        this.allowedHosts.clear();
+      if (allowedHosts !== undefined) {
         this.set('allowedHosts', allowedHosts);
       }
     }
 
-    return super.merge(obj, ['allowedHosts']);
+    return super.merge(obj, [...omit, 'allowedHosts']);
   }
 }

--- a/src/DevServer.js
+++ b/src/DevServer.js
@@ -1,13 +1,11 @@
 import ChainedMap from './ChainedMap.js';
-import ChainedSet from './ChainedSet.js';
 
 export default class extends ChainedMap {
   constructor(parent) {
     super(parent);
 
-    this.allowedHosts = new ChainedSet(this);
-
     this.extend([
+      'allowedHosts',
       'app',
       'client',
       'compress',
@@ -31,50 +29,7 @@ export default class extends ChainedMap {
     ]);
   }
 
-  clear() {
-    this.allowedHosts.clear();
-    return super.clear();
-  }
-
-  delete(key) {
-    if (key === 'allowedHosts') {
-      this.allowedHosts.clear();
-    }
-
-    return super.delete(key);
-  }
-
-  set(key, value) {
-    if (key !== 'allowedHosts') {
-      return super.set(key, value);
-    }
-
-    this.allowedHosts.clear();
-
-    if (Array.isArray(value)) {
-      this.allowedHosts.merge(value);
-      return super.delete(key);
-    }
-
-    return super.set(key, value);
-  }
-
   toConfig() {
-    return this.clean({
-      allowedHosts: this.allowedHosts.values(),
-      ...(this.entries() || {}),
-    });
-  }
-
-  merge(obj, omit = []) {
-    if (!omit.includes('allowedHosts') && 'allowedHosts' in obj) {
-      const { allowedHosts } = obj;
-
-      if (allowedHosts !== undefined) {
-        this.set('allowedHosts', allowedHosts);
-      }
-    }
-
-    return super.merge(obj, [...omit, 'allowedHosts']);
+    return this.clean(this.entries() || {});
   }
 }

--- a/test/DevServer.js
+++ b/test/DevServer.js
@@ -17,6 +17,28 @@ test('sets allowed hosts', () => {
   });
 });
 
+test('merges allowedHosts with non-array values', () => {
+  const devServer = new DevServer();
+
+  devServer.merge({
+    allowedHosts: 'auto',
+  });
+
+  expect(devServer.toConfig()).toStrictEqual({
+    allowedHosts: 'auto',
+  });
+});
+
+test('sets allowedHosts with non-array values', () => {
+  const devServer = new DevServer();
+
+  devServer.set('allowedHosts', 'all');
+
+  expect(devServer.toConfig()).toStrictEqual({
+    allowedHosts: 'all',
+  });
+});
+
 test('shorthand methods', () => {
   const devServer = new DevServer();
   const obj = {};

--- a/test/DevServer.js
+++ b/test/DevServer.js
@@ -29,6 +29,19 @@ test('merges allowedHosts with non-array values', () => {
   });
 });
 
+test('ignores undefined allowedHosts during merge', () => {
+  const devServer = new DevServer();
+
+  devServer.allowedHosts.add('https://github.com');
+  devServer.merge({
+    allowedHosts: undefined,
+  });
+
+  expect(devServer.toConfig()).toStrictEqual({
+    allowedHosts: ['https://github.com'],
+  });
+});
+
 test('sets allowedHosts with non-array values', () => {
   const devServer = new DevServer();
 
@@ -37,6 +50,55 @@ test('sets allowedHosts with non-array values', () => {
   expect(devServer.toConfig()).toStrictEqual({
     allowedHosts: 'all',
   });
+});
+
+test('clears stale allowedHosts entries when deleting scalar values', () => {
+  const devServer = new DevServer();
+
+  devServer.allowedHosts.add('https://github.com');
+  devServer.set('allowedHosts', 'all');
+  devServer.delete('allowedHosts');
+
+  expect(devServer.toConfig()).toStrictEqual({});
+});
+
+test('replaces scalar allowedHosts with array values during merge', () => {
+  const devServer = new DevServer();
+
+  devServer.allowedHosts.add('https://github.com');
+  devServer.set('allowedHosts', 'all');
+  devServer.merge({
+    allowedHosts: ['https://rspack.rs'],
+  });
+
+  expect(devServer.toConfig()).toStrictEqual({
+    allowedHosts: ['https://rspack.rs'],
+  });
+});
+
+test('preserves omitted keys during merge', () => {
+  const devServer = new DevServer();
+
+  devServer.proxy('https://example.com');
+  devServer.merge(
+    {
+      proxy: 'https://rspack.rs',
+    },
+    ['proxy'],
+  );
+
+  expect(devServer.toConfig()).toStrictEqual({
+    proxy: 'https://example.com',
+  });
+});
+
+test('clear removes allowedHosts values', () => {
+  const devServer = new DevServer();
+
+  devServer.allowedHosts.add('https://github.com');
+  devServer.clear();
+
+  expect(devServer.toConfig()).toStrictEqual({});
 });
 
 test('shorthand methods', () => {

--- a/test/DevServer.js
+++ b/test/DevServer.js
@@ -7,9 +7,9 @@ test('is Chainable', () => {
   expect(devServer.end()).toBe(parent);
 });
 
-test('sets allowed hosts', () => {
+test('sets allowed hosts arrays', () => {
   const devServer = new DevServer();
-  const instance = devServer.allowedHosts.add('https://github.com').end();
+  const instance = devServer.allowedHosts(['https://github.com']);
 
   expect(instance).toBe(devServer);
   expect(devServer.toConfig()).toStrictEqual({
@@ -17,62 +17,26 @@ test('sets allowed hosts', () => {
   });
 });
 
-test('merges allowedHosts with non-array values', () => {
+test('sets allowed hosts scalar values', () => {
   const devServer = new DevServer();
 
-  devServer.merge({
-    allowedHosts: 'auto',
-  });
-
-  expect(devServer.toConfig()).toStrictEqual({
-    allowedHosts: 'auto',
-  });
-});
-
-test('ignores undefined allowedHosts during merge', () => {
-  const devServer = new DevServer();
-
-  devServer.allowedHosts.add('https://github.com');
-  devServer.merge({
-    allowedHosts: undefined,
-  });
-
-  expect(devServer.toConfig()).toStrictEqual({
-    allowedHosts: ['https://github.com'],
-  });
-});
-
-test('sets allowedHosts with non-array values', () => {
-  const devServer = new DevServer();
-
-  devServer.set('allowedHosts', 'all');
+  devServer.allowedHosts('all');
 
   expect(devServer.toConfig()).toStrictEqual({
     allowedHosts: 'all',
   });
 });
 
-test('clears stale allowedHosts entries when deleting scalar values', () => {
+test('merges allowedHosts values', () => {
   const devServer = new DevServer();
 
-  devServer.allowedHosts.add('https://github.com');
-  devServer.set('allowedHosts', 'all');
-  devServer.delete('allowedHosts');
-
-  expect(devServer.toConfig()).toStrictEqual({});
-});
-
-test('replaces scalar allowedHosts with array values during merge', () => {
-  const devServer = new DevServer();
-
-  devServer.allowedHosts.add('https://github.com');
-  devServer.set('allowedHosts', 'all');
+  devServer.allowedHosts('auto');
   devServer.merge({
-    allowedHosts: ['https://rspack.rs'],
+    allowedHosts: ['https://github.com'],
   });
 
   expect(devServer.toConfig()).toStrictEqual({
-    allowedHosts: ['https://rspack.rs'],
+    allowedHosts: ['https://github.com'],
   });
 });
 
@@ -90,15 +54,6 @@ test('preserves omitted keys during merge', () => {
   expect(devServer.toConfig()).toStrictEqual({
     proxy: 'https://example.com',
   });
-});
-
-test('clear removes allowedHosts values', () => {
-  const devServer = new DevServer();
-
-  devServer.allowedHosts.add('https://github.com');
-  devServer.clear();
-
-  expect(devServer.toConfig()).toStrictEqual({});
 });
 
 test('shorthand methods', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -236,14 +236,10 @@ export declare namespace RspackChain {
   type RspackDevServer = NonNullable<Configuration['devServer']>;
 
   type DevServerShorthandMethods<T> = {
-    [K in Exclude<keyof RspackDevServer, 'allowedHosts'>]-?: (
-      value: RspackDevServer[K],
-    ) => T;
+    [K in keyof RspackDevServer]-?: (value: RspackDevServer[K]) => T;
   };
 
-  class DevServer extends TypedChainedMap<RspackChain, RspackDevServer> {
-    allowedHosts: TypedChainedSet<this, string>;
-  }
+  class DevServer extends TypedChainedMap<RspackChain, RspackDevServer> {}
 
   interface DevServer extends DevServerShorthandMethods<DevServer> {}
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -233,7 +233,7 @@ export declare namespace RspackChain {
     clean(value: RspackOutput['clean']): this;
   }
 
-  type RspackDevServer = NonNullable<Configuration['devServer']>;
+  type RspackDevServer = Required<NonNullable<Configuration['devServer']>>;
 
   type DevServerShorthandMethods<T> = {
     [K in keyof RspackDevServer]-?: (value: RspackDevServer[K]) => T;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
-import { Configuration, Compiler, RuleSetRule } from '@rspack/core';
-import * as https from 'node:https';
+import { Configuration, RuleSetRule } from '@rspack/core';
 
 // The compiler type of Rspack / webpack are mismatch,
 // so we use a loose type here to allow using webpack plugins.
@@ -234,86 +233,19 @@ export declare namespace RspackChain {
     clean(value: RspackOutput['clean']): this;
   }
 
-  // await for @types/webpack-dev-server update do v4 to remove all any
-  class DevServer extends ChainedMap<RspackChain> {
+  type RspackDevServer = NonNullable<Configuration['devServer']>;
+
+  type DevServerShorthandMethods<T> = {
+    [K in Exclude<keyof RspackDevServer, 'allowedHosts'>]-?: (
+      value: RspackDevServer[K],
+    ) => T;
+  };
+
+  class DevServer extends TypedChainedMap<RspackChain, RspackDevServer> {
     allowedHosts: TypedChainedSet<this, string>;
-    after(value: (app: any, server: any, compiler: Compiler) => void): this;
-    before(value: (app: any, server: any, compiler: Compiler) => void): this;
-    bonjour(value: boolean): this;
-    clientLogLevel(
-      value:
-        | 'silent'
-        | 'trace'
-        | 'debug'
-        | 'info'
-        | 'warn'
-        | 'error'
-        | 'none'
-        | 'warning',
-    ): this;
-    compress(value: boolean): this;
-    contentBase(value: boolean | string | string[]): this;
-    contentBasePublicPath(value: string): this;
-    disableHostCheck(value: boolean): this;
-    filename(value: string): this;
-    headers(value: { [header: string]: string }): this;
-    historyApiFallback(value: boolean | any): this;
-    host(value: string): this;
-    hot(value: boolean): this;
-    hotOnly(value: boolean): this;
-    http2(value: boolean): this;
-    https(value: boolean | https.ServerOptions): this;
-    index(value: string): this;
-    injectClient(value: boolean | ((compiler: Compiler) => boolean)): this;
-    injectHot(value: boolean | ((compiler: Compiler) => boolean)): this;
-    inline(value: boolean): this;
-    lazy(value: boolean): this;
-    liveReload(value: boolean): this;
-    mimeTypes(value: Object): this;
-    noInfo(value: boolean): this;
-    onListening(value: (server: any) => void): this;
-    open(value: boolean): this;
-    openPage(value: string | string[]): this;
-    overlay(value: boolean | { warnings?: boolean; errors?: boolean }): this;
-    pfx(value: string): this;
-    pfxPassphrase(value: string): this;
-    port(value: number): this;
-    progress(value: boolean): this;
-    proxy(value: any): this;
-    public(value: string): this;
-    publicPath(publicPath: string): this;
-    quiet(value: boolean): this;
-    serveIndex(value: boolean): this;
-    setup(value: (expressApp: any) => void): this;
-    socket(value: string): this;
-    sockHost(value: string): this;
-    sockPath(value: string): this;
-    sockPort(value: number): this;
-    staticOptions(value: any): this;
-    stats(value: Configuration['stats']): this;
-    stdin(value: boolean): this;
-    transportMode(
-      value:
-        | 'sockjs'
-        | 'ws'
-        | {
-            server: 'ws';
-            client: object;
-          }
-        | {
-            client: 'sockjs';
-            server: object;
-          }
-        | {
-            client: object;
-            server: object;
-          },
-    ): this;
-    useLocalIp(value: boolean): this;
-    watchContentBase(value: boolean): this;
-    watchOptions(value: Configuration['watchOptions']): this;
-    writeToDisk(value: boolean): this;
   }
+
+  interface DevServer extends DevServerShorthandMethods<DevServer> {}
 
   type RspackPerformance = Exclude<
     Required<NonNullable<Configuration['performance']>>,

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -265,10 +265,8 @@ config
   .delete('asObject')
   .end()
   // devServer
-  .devServer.allowedHosts.add('host.com')
-  .clear()
-  .end()
-  .set('allowedHosts', 'auto')
+  .devServer.allowedHosts(['host.com'])
+  .allowedHosts('auto')
   .merge({
     allowedHosts: ['host.com'],
     hot: 'only',

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -268,70 +268,80 @@ config
   .devServer.allowedHosts.add('host.com')
   .clear()
   .end()
-  .after(() => {})
-  .before(() => {})
-  .bonjour(true)
-  .clientLogLevel('error')
+  .set('allowedHosts', 'auto')
+  .merge({
+    allowedHosts: ['host.com'],
+    hot: 'only',
+  })
+  .app(async () => {
+    throw new Error('not used in type tests');
+  })
+  .client({
+    logging: 'warn',
+    overlay: {
+      warnings: true,
+      errors: true,
+      runtimeErrors: false,
+    },
+    progress: true,
+    reconnect: 3,
+    webSocketTransport: 'ws',
+    webSocketURL: {
+      protocol: 'ws',
+      port: 8080,
+    },
+  })
   .compress(false)
-  .contentBase('/')
-  .contentBase(['foo', 'bar'])
-  .contentBasePublicPath('asd')
-  .disableHostCheck(true)
-  .filename('hello')
+  .devMiddleware({
+    index: 'index.html',
+    mimeTypes: {
+      'text/html': 'text/html',
+    },
+    stats: 'errors-warnings',
+    writeToDisk: true,
+  })
   .headers({
     'Content-Type': 'text/css',
   })
+  .headers((req, res, context) => ({
+    'X-Test': 'true',
+  }))
   .historyApiFallback(true)
   .host('localhost')
   .hot(true)
-  .hotOnly(true)
-  .http2(true)
-  .https(true)
-  .index('test.html')
-  .injectClient(false)
-  .injectHot(() => false)
-  .inline(true)
-  .lazy(true)
-  .mimeTypes({ 'text/html': ['phtml'] })
-  .noInfo(true)
+  .ipc(true)
+  .liveReload(true)
   .open(true)
-  .openPage('/foo')
-  .openPage(['/foo', '/bar'])
-  .overlay(true)
-  .overlay({
-    warnings: true,
-    errors: true,
-  })
-  .pfx('/path/to/file.pfx')
-  .pfxPassphrase('passphrase')
   .port(8080)
-  .progress(true)
-  .proxy({})
-  .public('foo')
-
-  .publicPath('bar')
-  .quiet(false)
-  .setup((app) => {})
-  .socket('socket')
-  .sockHost('localhost')
-  .sockPath('/sockpath/')
-  .sockPort(8080)
-  .staticOptions({})
-  .stats({
-    reasons: true,
-    errors: true,
-    warnings: false,
+  .proxy([
+    {
+      context: ['/api'],
+      target: 'http://localhost:3000',
+    },
+  ])
+  .server({
+    type: 'https',
+    options: {},
   })
-  .transportMode('sockjs')
-  .transportMode({
-    client: {},
-    server: 'ws',
+  .setupExitSignals(true)
+  .setupMiddlewares((middlewares) => middlewares)
+  .static({
+    directory: '/tmp/public',
+    publicPath: ['/assets'],
+    watch: {
+      poll: 1000,
+    },
   })
-  .stdin(true)
-  .useLocalIp(true)
-  .watchContentBase(true)
-  .watchOptions({})
-  .writeToDisk(true)
+  .watchFiles([
+    'src/**/*',
+    {
+      paths: ['templates/**/*'],
+      options: {
+        poll: 1000,
+      },
+    },
+  ])
+  .webSocketServer('ws')
   .end()
   // performance
   .performance(false)


### PR DESCRIPTION
## Summary

This PR aligns `rspack-chain`'s `devServer` API with Rspack's current `Configuration['devServer']` shape. It removes shorthand methods for deprecated dev-server options, updates the runtime and type declarations to match the current option set, and adds coverage for `allowedHosts` scalar values plus the updated type surface.

## Test Plan

- `pnpm test:types`
- `pnpm test`
- `pnpm exec prettier --check README.md src/DevServer.js types/index.d.ts types/test/rspack-chain-tests.ts test/DevServer.js`

## Related Links

- https://v2.rspack.rs/config/dev-server