### PR TITLE
fix(types): exclude false devServer config

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -233,7 +233,9 @@ export declare namespace RspackChain {
     clean(value: RspackOutput['clean']): this;
   }
 
-  type RspackDevServer = Required<NonNullable<Configuration['devServer']>>;
+  type RspackDevServer = Required<
+    Exclude<Configuration['devServer'], false | null | undefined>
+  >;
 
   type DevServerShorthandMethods<T> = {
     [K in keyof RspackDevServer]-?: (value: RspackDevServer[K]) => T;


### PR DESCRIPTION
## Summary

This PR fixes the type alias used for `devServer` config after upgrading to `@rspack/core@2.0.0-rc.1`.
`Configuration['devServer']` now includes `false`, so the previous `Required<NonNullable<...>>` alias could retain `false` and break chained `DevServer` typings. This change explicitly excludes `false | null | undefined` before applying `Required`, which restores the expected method surface and makes the type tests pass again.

## Related Links

- https://github.com/rstackjs/rspack-chain/pull/93
- https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-rc.1

## Validation

- `pnpm run test:types`
