### PR TITLE
fix: align resolve alias types with Rspack

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -272,8 +272,9 @@ export declare namespace RspackChain {
   }
 
   type RspackResolve = Required<NonNullable<Configuration['resolve']>>;
+  type RspackResolveAlias = Exclude<RspackResolve['alias'], false>;
   class Resolve<T = RspackChain> extends ChainedMap<T> {
-    alias: TypedChainedMap<this, { [key: string]: string | false | string[] }>;
+    alias: TypedChainedMap<this, RspackResolveAlias>;
     aliasFields: TypedChainedSet<this, RspackResolve['aliasFields'][number]>;
     conditionNames: TypedChainedSet<
       this,
@@ -298,10 +299,7 @@ export declare namespace RspackChain {
     restrictions: TypedChainedSet<this, RspackResolve['restrictions'][number]>;
     roots: TypedChainedSet<this, RspackResolve['roots'][number]>;
     modules: TypedChainedSet<this, RspackResolve['modules'][number]>;
-    fallback: TypedChainedMap<
-      this,
-      { [key: string]: string | false | string[] }
-    >;
+    fallback: TypedChainedMap<this, RspackResolveAlias>;
     byDependency: TypedChainedMap<this, RspackResolve['byDependency']>;
     enforceExtension(value: RspackResolve['enforceExtension']): this;
     fullySpecified(value: RspackResolve['fullySpecified']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -168,6 +168,7 @@ config
   .resolve.alias.set('foo', 'bar')
   .set('foo', false)
   .set('foo', ['asd'])
+  .set('foo', ['asd', false])
   .end()
   .tsConfig('./tsconfig.json')
   .delete('tsConfig')
@@ -200,7 +201,7 @@ config
   .end()
   .roots.add('asdasd')
   .end()
-  .fallback.set('asd', ['asdasd'])
+  .fallback.set('asd', ['asdasd', false])
   .end()
   .byDependency.set('esm', {
     mainFields: ['browser', 'module'],


### PR DESCRIPTION
## Summary

- derive the chained resolve alias value type from Rspack’s `Configuration` type
- support `false` entries in alias and fallback arrays
- add type coverage for mixed string/false arrays

Type source: https://github.com/web-infra-dev/rspack/blob/357f38b3fbd22b9611ea24e58d61716fb2293b47/packages/rspack/src/config/types.ts#L708

## Testing

- `pnpm run test:types`
- `pnpm run build`
- `pnpm run test`
- `pnpm run lint`
- `pnpm exec prettier --check types/index.d.ts types/test/rspack-chain-tests.ts`