### PR TITLE
fix: handle array entry values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,11 @@ const toEntryObject = (entryPoints) => {
         continue;
       }
 
+      if (Array.isArray(item)) {
+        entryImport.push(...item);
+        continue;
+      }
+
       if (item.import) {
         entryImport.push(...castArray(item.import));
       }

--- a/test/Config.js
+++ b/test/Config.js
@@ -124,6 +124,28 @@ test('entry', () => {
   });
 });
 
+test('entry array', () => {
+  const config = new RspackChain();
+
+  config.entry('array').add(['src/a.js', 'src/b.js']);
+  config
+    .entry('mixed')
+    .add(['src/a.js', 'src/b.js'])
+    .add('src/c.js')
+    .add({
+      import: ['src/d.js', 'src/e.js'],
+      dependOn: 'shared',
+    });
+
+  expect(config.toConfig().entry).toStrictEqual({
+    array: ['src/a.js', 'src/b.js'],
+    mixed: {
+      import: ['src/a.js', 'src/b.js', 'src/c.js', 'src/d.js', 'src/e.js'],
+      dependOn: 'shared',
+    },
+  });
+});
+
 test('entry description object', () => {
   const config = new RspackChain();
 


### PR DESCRIPTION
`entry.add(string[])` previously treated the array as an entry description and emitted numeric properties with an empty `import` list. This change flattens array entries into the final import list and adds regression coverage for both array-only and mixed entry values. Validated with the build, unit tests, type tests, lint, and Prettier checks.