### PR TITLE
fix(types): restrict node and performance values

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,9 +63,9 @@ export declare class RspackChain extends __Config.ChainedMap<void> {
   >;
   output: RspackChain.Output;
   module: RspackChain.Module;
-  node: RspackChain.ChainedMap<this> & ((value: boolean) => this);
+  node: RspackChain.ChainedMap<this> & ((value: false) => this);
   optimization: RspackChain.Optimization;
-  performance: RspackChain.Performance & ((value: boolean) => this);
+  performance: RspackChain.Performance & ((value: false) => this);
   plugins: RspackChain.Plugins<this, PluginInstance>;
   resolve: RspackChain.Resolve;
   resolveLoader: RspackChain.ResolveLoader;


### PR DESCRIPTION
Rspack only accepts `false` as the boolean shorthand for `node` and `performance`, while the current declarations also allow `true`. This PR narrows both callable parameters to `false` without changing runtime behavior or adding tests. Validated with the type checks, lint, and Prettier.