### PR TITLE
fix(types): support string loader options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -398,9 +398,7 @@ export declare namespace RspackChain {
     [name: string]: any;
   }
 
-  interface LoaderOptions {
-    [name: string]: any;
-  }
+  type LoaderOptions = NonNullable<RuleSetLoaderWithOptions['options']>;
 
   type LoaderParallelOptions = NonNullable<
     RuleSetLoaderWithOptions['parallel']

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -115,6 +115,7 @@ config
   .ident('babel-loader-ident')
   .loader('babel-loader')
   .options({})
+  .options('cacheDirectory=true')
   .parallel(true)
   .parallel({ maxWorkers: 2 })
   .end()


### PR DESCRIPTION
Rspack accepts loader options as either a string or an object, while rspack-chain currently restricts them to objects.

This PR derives `LoaderOptions` from `RuleSetLoaderWithOptions['options']` so both valid forms are accepted, and adds a type test covering string options.

Validated with:
- `pnpm run build`
- `pnpm run test`
- `pnpm run test:types`
- `pnpm run lint`
- `pnpm exec prettier --check types/index.d.ts types/test/rspack-chain-tests.ts`