### PR TITLE
fix: support disabling dev server

### DIFF
--- a/src/DevServer.js
+++ b/src/DevServer.js
@@ -1,6 +1,6 @@
-import ChainedMap from './ChainedMap.js';
+import ChainedValueMap from './ChainedValueMap.js';
 
-export default class extends ChainedMap {
+export default class extends ChainedValueMap {
   constructor(parent) {
     super(parent);
 
@@ -30,6 +30,8 @@ export default class extends ChainedMap {
   }
 
   toConfig() {
-    return this.clean(this.entries() || {});
+    const config = this.entries();
+
+    return config === false ? false : this.clean(config || {});
   }
 }

--- a/test/Config.js
+++ b/test/Config.js
@@ -67,6 +67,14 @@ test('performance is false', () => {
   expect(config.performance.entries()).toStrictEqual(false);
 });
 
+test('devServer is false', () => {
+  const config = new RspackChain();
+  const instance = config.devServer(false);
+
+  expect(instance).toBe(config);
+  expect(config.toConfig()).toStrictEqual({ devServer: false });
+});
+
 test('bail', () => {
   const config = new RspackChain();
   const instance = config.bail(false);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,7 +69,7 @@ export declare class RspackChain extends __Config.ChainedMap<void> {
   plugins: RspackChain.Plugins<this, PluginInstance>;
   resolve: RspackChain.Resolve;
   resolveLoader: RspackChain.ResolveLoader;
-  devServer: RspackChain.DevServer;
+  devServer: RspackChain.DevServer & ((value: false) => this);
 
   context(value: RspackConfig['context']): this;
   mode(value: RspackConfig['mode']): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -287,6 +287,7 @@ config
   .delete('asObject')
   .end()
   // devServer
+  .devServer(false)
   .devServer.allowedHosts(['host.com'])
   .allowedHosts('auto')
   .merge({


### PR DESCRIPTION
Rspack allows `devServer: false`, but rspack-chain's dev server chain was a non-callable map and its serializer discarded false values. This PR makes it a value-capable chained map, exposes `config.devServer(false)` in the types, and adds runtime and type coverage. Build, 194 unit tests, type checks, lint, and formatting all pass.