### PR TITLE
fix: respect omit in module merge

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -46,6 +46,6 @@ export default class extends ChainedMap {
       );
     }
 
-    return super.merge(obj, ['rule', 'defaultRule']);
+    return super.merge(obj, [...omit, 'rule', 'defaultRule']);
   }
 }

--- a/test/Module.js
+++ b/test/Module.js
@@ -48,3 +48,12 @@ test('toConfig with values', () => {
     noParse: /.min.js/,
   });
 });
+
+test('merge with omitting keys', () => {
+  const module = new Module();
+
+  module.noParse(/original/);
+  module.merge({ noParse: /new-value/ }, ['noParse']);
+
+  expect(module.toConfig()).toStrictEqual({ noParse: /original/ });
+});


### PR DESCRIPTION
`Module.merge()` currently drops the caller-provided omit list when delegating to `ChainedMap`, causing omitted module options such as `noParse` to be merged anyway. This PR forwards the omitted keys and adds regression coverage.