### PR TITLE
fix: remove broken plugin path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,10 +747,6 @@ config.optimization
 _NOTE: Do not use `new` to create the minimizer plugin, as this will be done for you._
 
 ```js
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
 config.optimization.minimizer(name).use(RspackPlugin, args);
 
 // Examples
@@ -758,14 +754,6 @@ config.optimization.minimizer(name).use(RspackPlugin, args);
 config.optimization
   .minimizer('css')
   .use(OptimizeCSSAssetsPlugin, [{ cssProcessorOptions: { safe: true } }]);
-
-// Minimizer plugins can also be specified by their path, allowing the expensive module loads to be
-// skipped in cases where the plugin or Rspack configuration won't end up being used.
-config.optimization
-  .minimizer('css')
-  .use(require.resolve('optimize-css-assets-webpack-plugin'), [
-    { cssProcessorOptions: { safe: true } },
-  ]);
 ```
 
 #### optimization minimizers: modify arguments
@@ -818,10 +806,7 @@ config.plugin(name) : ChainedMap
 _NOTE: Do not use `new` to create the plugin, as this will be done for you._
 
 ```js
-import { createRequire } from 'node:module';
 import { HotModuleReplacementPlugin, EnvironmentPlugin } from '@rspack/core';
-
-const require = createRequire(import.meta.url);
 
 config.plugin(name).use(RspackPlugin, args);
 
@@ -829,11 +814,7 @@ config.plugin(name).use(RspackPlugin, args);
 
 config.plugin('hot').use(HotModuleReplacementPlugin);
 
-// Plugins can also be specified by their path, allowing the expensive module loads to be
-// skipped in cases where the plugin or Rspack configuration won't end up being used.
 config.plugin('env').use(EnvironmentPlugin, [{ VAR: false }]);
-
-config.plugin('custom').use(require.resolve('my-plugin'), [{ answer: 42 }]);
 ```
 
 #### plugins: modify arguments

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -32,6 +32,11 @@ export default Orderable(
     }
 
     set(key, value) {
+      if (key === 'plugin' && typeof value === 'string') {
+        throw new TypeError(
+          'Plugin paths are not supported. Import the plugin and pass it to .use() instead.',
+        );
+      }
       if (key === 'args' && !Array.isArray(value)) {
         throw new Error('args must be an array of arguments');
       }
@@ -52,22 +57,13 @@ export default Orderable(
 
     toConfig() {
       const init = this.get('init');
-      let plugin = this.get('plugin');
+      const plugin = this.get('plugin');
       const args = this.get('args');
-      let pluginPath = null;
 
       if (plugin === undefined) {
         throw new Error(
           `Invalid ${this.type} configuration: ${this.type}('${this.name}').use(<Plugin>) was not called to specify the plugin`,
         );
-      }
-
-      // Support using the path to a plugin rather than the plugin itself,
-      // allowing expensive require()s to be skipped in cases where the plugin
-      // or Rspack configuration won't end up being used.
-      if (typeof plugin === 'string') {
-        pluginPath = plugin;
-        plugin = require(pluginPath);
       }
 
       const constructorName = plugin.__expression
@@ -81,7 +77,6 @@ export default Orderable(
         __pluginType: { value: this.type },
         __pluginArgs: { value: args },
         __pluginConstructorName: { value: constructorName },
-        __pluginPath: { value: pluginPath },
       });
 
       return config;

--- a/src/index.js
+++ b/src/index.js
@@ -105,11 +105,7 @@ class RspackChain extends ChainedMap {
         // improve plugin output
         if (value && value.__pluginName) {
           const prefix = `/* ${configPrefix}.${value.__pluginType}('${value.__pluginName}') */\n`;
-          const constructorExpression = value.__pluginPath
-            ? // The path is stringified to ensure special characters are escaped
-              // (such as the backslashes in Windows-style paths).
-              `(require(${stringify(value.__pluginPath)}))`
-            : value.__pluginConstructorName;
+          const constructorExpression = value.__pluginConstructorName;
 
           if (constructorExpression) {
             // get correct indentation for args by stringifying the args array and

--- a/test-utils/PathEnvironmentPlugin.cjs
+++ b/test-utils/PathEnvironmentPlugin.cjs
@@ -1,9 +1,0 @@
-class PathEnvironmentPlugin {
-  constructor(...args) {
-    this.values = args;
-  }
-
-  apply() {}
-}
-
-module.exports = PathEnvironmentPlugin;

--- a/test/Config.js
+++ b/test/Config.js
@@ -1,11 +1,5 @@
 import { EnvironmentPlugin } from '@rspack/core';
-import { stringify } from 'javascript-stringify';
 import { RspackChain } from '../dist';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const pathEnvironmentPlugin =
-  require.resolve('../test-utils/PathEnvironmentPlugin.cjs');
 
 class StringifyPlugin {
   constructor(...args) {
@@ -509,15 +503,12 @@ test('toString', () => {
     .use('babel')
     .loader('babel-loader');
 
-  const envPluginPath = pathEnvironmentPlugin;
-  const stringifiedEnvPluginPath = stringify(envPluginPath);
-
   class FooPlugin {}
   FooPlugin.__expression = `require('foo-plugin')`;
 
   config
     .plugin('env')
-    .use(envPluginPath, [{ VAR: false }])
+    .use(EnvironmentPlugin, [{ VAR: false }])
     .end()
     .plugin('gamma')
     .use(FooPlugin)
@@ -586,7 +577,7 @@ test('toString', () => {
   },
   plugins: [
     /* config.plugin('env') */
-    new (require(${stringifiedEnvPluginPath}))(
+    new EnvironmentPlugin(
       {
         VAR: false
       }

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -1,9 +1,4 @@
 import Plugin from '../src/Plugin';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const pathEnvironmentPlugin =
-  require.resolve('../test-utils/PathEnvironmentPlugin.cjs');
 
 class StringifyPlugin {
   constructor(...args) {
@@ -29,6 +24,14 @@ test('use', () => {
   expect(instance).toBe(plugin);
   expect(plugin.get('plugin')).toBe(StringifyPlugin);
   expect(plugin.get('args')).toStrictEqual(['alpha', 'beta']);
+});
+
+test('use rejects plugin paths', () => {
+  const plugin = new Plugin();
+
+  expect(() => plugin.use('plugin-path')).toThrow(
+    'Plugin paths are not supported. Import the plugin and pass it to .use() instead.',
+  );
 });
 
 test('tap', () => {
@@ -128,17 +131,6 @@ test('toConfig with object literal plugin', () => {
   const initialized = plugin.toConfig();
 
   expect(initialized).toBe(TestPlugin);
-});
-
-test('toConfig with plugin as path', () => {
-  const plugin = new Plugin(null, 'gamma');
-  plugin.use(pathEnvironmentPlugin);
-
-  const initialized = plugin.toConfig();
-
-  expect(initialized.constructor.name).toBe('PathEnvironmentPlugin');
-  expect(initialized.__pluginConstructorName).toBe('PathEnvironmentPlugin');
-  expect(initialized.__pluginPath).toBe(pathEnvironmentPlugin);
 });
 
 test('toConfig without having called use()', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ export declare namespace RspackChain {
           : any[],
       ) => PluginType,
     ): this;
-    use<P extends string | PluginType | PluginClass<PluginType>>(
+    use<P extends PluginType | PluginClass<PluginType>>(
       plugin: P,
       args?: P extends PluginClass<PluginType>
         ? ConstructorParameters<P>

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -272,10 +272,6 @@ config
   .after('bar')
   .end()
 
-  .plugin('asString')
-  .use('package-name-or-path')
-  .end()
-
   .plugin('asObject')
   .use({ apply: (compiler: rspack.Compiler) => {} })
   .end()
@@ -283,7 +279,6 @@ config
   .plugins.delete('foo')
   .delete('bar')
   .delete('baz')
-  .delete('asString')
   .delete('asObject')
   .end()
   // devServer
@@ -421,6 +416,9 @@ config
   // end
   .merge({})
   .toConfig();
+
+// @ts-expect-error plugin paths are not supported
+config.plugin('asString').use('package-name-or-path');
 
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;


### PR DESCRIPTION
`rspack-chain` v2 is ESM-only, so string plugin paths have always failed with `require is not defined` in the supported runtime. This PR removes that unusable API from runtime, types, serialization, tests, and docs; JavaScript callers now receive an actionable error directing them to import the plugin before passing it to `.use()`.