### PR TITLE
fix(types): infer get return types for known config keys

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,7 +36,15 @@ declare namespace __Config {
     ): this;
   }
 
-  class ChainedMap<Parent> extends TypedChainedMap<Parent, any> {}
+  class ChainedMap<Parent, OptionsType = any> extends TypedChainedMap<
+    Parent,
+    any
+  > {
+    // Keep custom keys and chain-specific set/merge inputs compatible.
+    get<Key extends PropertyKey>(
+      key: Key,
+    ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
+  }
   class TypedChainedSet<Parent, Value> extends Chained<Parent> {
     add(value: Value): this;
     prepend(value: Value): this;
@@ -56,7 +64,10 @@ declare namespace __Config {
 }
 
 type RspackConfig = Required<Configuration>;
-export declare class RspackChain extends __Config.ChainedMap<void> {
+export declare class RspackChain extends __Config.ChainedMap<
+  void,
+  Configuration
+> {
   entryPoints: RspackChain.TypedChainedMap<
     RspackChain,
     { [key: string]: RspackChain.EntryPoint }
@@ -117,7 +128,10 @@ export declare namespace RspackChain {
     Parent,
     OptionsType
   > {}
-  class ChainedMap<Parent> extends __Config.TypedChainedMap<Parent, any> {}
+  class ChainedMap<Parent, OptionsType = any> extends __Config.ChainedMap<
+    Parent,
+    OptionsType
+  > {}
   class TypedChainedSet<Parent, Value> extends __Config.TypedChainedSet<
     Parent,
     Value
@@ -182,7 +196,10 @@ export declare namespace RspackChain {
 
   type RspackOutput = Required<NonNullable<Configuration['output']>>;
 
-  class Output extends ChainedMap<RspackChain> {
+  class Output extends ChainedMap<
+    RspackChain,
+    NonNullable<Configuration['output']>
+  > {
     assetModuleFilename(value: RspackOutput['assetModuleFilename']): this;
     asyncChunks(value: RspackOutput['asyncChunks']): this;
     bundlerInfo(value: RspackOutput['bundlerInfo']): this;
@@ -321,7 +338,10 @@ export declare namespace RspackChain {
 
   type RspackRuleSet = Required<RuleSetRule>;
 
-  class Rule<T = Module> extends ChainedMap<T> implements Orderable {
+  class Rule<T = Module>
+    extends ChainedMap<T, RuleSetRule>
+    implements Orderable
+  {
     uses: TypedChainedMap<this, { [key: string]: Use }>;
     include: TypedChainedSet<this, RspackRuleSet['include']>;
     exclude: TypedChainedSet<this, RspackRuleSet['exclude']>;
@@ -405,7 +425,10 @@ export declare namespace RspackChain {
     RuleSetLoaderWithOptions['parallel']
   >;
 
-  class Use<Parent = Rule> extends ChainedMap<Parent> implements Orderable {
+  class Use<Parent = Rule>
+    extends ChainedMap<Parent, RuleSetLoaderWithOptions>
+    implements Orderable
+  {
     ident(value: NonNullable<RuleSetLoaderWithOptions['ident']>): this;
     loader(value: string): this;
     options(value: LoaderOptions): this;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -7,6 +7,16 @@ import { RspackChain } from 'rspack-chain';
 
 function expectType<T>(value: T) {}
 
+// Unlike assignability checks, this also rejects an unexpected `any`.
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+
+function expectTypeEqual<A, B>(
+  ..._args: Equal<A, B> extends true ? [] : [never]
+) {}
+
 const config = new RspackChain();
 
 config
@@ -419,6 +429,38 @@ config
 
 // @ts-expect-error plugin paths are not supported
 config.plugin('asString').use('package-name-or-path');
+
+// Known keys return precise types, including undefined for unset values.
+const experiments = config.get('experiments');
+expectTypeEqual<typeof experiments, rspack.Configuration['experiments']>();
+
+const library = config.output.get('library');
+expectTypeEqual<
+  typeof library,
+  NonNullable<rspack.Configuration['output']>['library']
+>();
+
+const cssRule = config.module.rule('css');
+const resourceQuery = cssRule.get('resourceQuery');
+expectTypeEqual<typeof resourceQuery, rspack.RuleSetRule['resourceQuery']>();
+
+const swcUse = cssRule.use('swc');
+const loader = swcUse.get('loader');
+expectTypeEqual<typeof loader, string | undefined>();
+
+const loaderOptions = swcUse.get('options');
+expectTypeEqual<
+  typeof loaderOptions,
+  rspack.RuleSetLoaderWithOptions['options']
+>();
+
+// Custom keys and chain-specific merge structures remain compatible.
+const metadata = config.set('customMetadata', true).get('customMetadata');
+expectTypeEqual<typeof metadata, any>();
+config.merge({
+  plugin: { example: { plugin: rspack.DefinePlugin, args: [{}] } },
+});
+cssRule.merge({ use: { swc: { loader: 'builtin:swc-loader' } } });
 
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;


### PR DESCRIPTION
`get()` currently returns `any` for configuration keys, forcing consumers to add type assertions. This PR infers the value types for known keys on `RspackChain`, `Output`, `Rule`, and `Use`, including `undefined` for unset values.

Custom keys and existing `set()`/`merge()` inputs remain compatible. Consumers may need to handle missing values or narrow union types that were previously hidden by `any`.