### PR TITLE
fix(types): validate writes to known config keys

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,8 @@ interface PluginInstance {
 }
 
 declare namespace __Config {
+  type MergeInput<OptionsType> = Partial<OptionsType> & Record<string, any>;
+
   class Chained<Parent> {
     batch(handler: (chained: this) => void): this;
     end(): Parent;
@@ -36,14 +38,26 @@ declare namespace __Config {
     ): this;
   }
 
-  class ChainedMap<Parent, OptionsType = any> extends TypedChainedMap<
+  class ChainedMap<
     Parent,
-    any
-  > {
-    // Keep custom keys and chain-specific set/merge inputs compatible.
+    OptionsType = any,
+    MergeOptions = OptionsType,
+  > extends TypedChainedMap<Parent, any> {
+    // Known keys share their read/write types; custom keys remain unrestricted.
     get<Key extends PropertyKey>(
       key: Key,
     ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
+    set<Key extends PropertyKey>(
+      key: Key,
+      value: Key extends keyof OptionsType ? OptionsType[Key] | undefined : any,
+    ): this;
+    getOrCompute<Key extends PropertyKey>(
+      key: Key,
+      compute: Key extends keyof OptionsType
+        ? () => OptionsType[Key] | undefined
+        : () => any,
+    ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
+    merge(obj: MergeInput<MergeOptions>, omit?: string[]): this;
   }
   class TypedChainedSet<Parent, Value> extends Chained<Parent> {
     add(value: Value): this;
@@ -66,7 +80,8 @@ declare namespace __Config {
 type RspackConfig = Required<Configuration>;
 export declare class RspackChain extends __Config.ChainedMap<
   void,
-  Configuration
+  Configuration,
+  RspackChain.ConfigMergeOptions
 > {
   entryPoints: RspackChain.TypedChainedMap<
     RspackChain,
@@ -128,10 +143,11 @@ export declare namespace RspackChain {
     Parent,
     OptionsType
   > {}
-  class ChainedMap<Parent, OptionsType = any> extends __Config.ChainedMap<
+  class ChainedMap<
     Parent,
-    OptionsType
-  > {}
+    OptionsType = any,
+    MergeOptions = OptionsType,
+  > extends __Config.ChainedMap<Parent, OptionsType, MergeOptions> {}
   class TypedChainedSet<Parent, Value> extends __Config.TypedChainedSet<
     Parent,
     Value
@@ -184,7 +200,33 @@ export declare namespace RspackChain {
 
   type RspackModule = Required<NonNullable<Configuration['module']>>;
 
-  class Module extends ChainedMap<RspackChain> {
+  // merge() accepts named child maps rather than the arrays in Rspack configs.
+  type RuleMergeOptions = Omit<RuleSetRule, 'use' | 'rules' | 'oneOf'> & {
+    use?: Record<string, __Config.MergeInput<RuleSetLoaderWithOptions>>;
+    rules?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
+    oneOf?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
+  };
+
+  type ModuleMergeOptions = NonNullable<Configuration['module']> & {
+    rule?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
+    defaultRule?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
+  };
+
+  type ConfigMergeOptions = Omit<
+    Configuration,
+    'entry' | 'module' | 'optimization' | 'output'
+  > & {
+    entry?: Record<string, RspackEntryObject | RspackEntryObject[]>;
+    module?: __Config.MergeInput<ModuleMergeOptions>;
+    output?: __Config.MergeInput<NonNullable<Configuration['output']>>;
+    optimization?: __Config.MergeInput<
+      Omit<NonNullable<Configuration['optimization']>, 'minimizer'> & {
+        minimizer?: Record<string, any>;
+      }
+    >;
+  };
+
+  class Module extends ChainedMap<RspackChain, any, ModuleMergeOptions> {
     defaultRules: TypedChainedMap<this, { [key: string]: Rule }>;
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
     generator: ChainedMap<this>;
@@ -339,7 +381,7 @@ export declare namespace RspackChain {
   type RspackRuleSet = Required<RuleSetRule>;
 
   class Rule<T = Module>
-    extends ChainedMap<T, RuleSetRule>
+    extends ChainedMap<T, RuleSetRule, RuleMergeOptions>
     implements Orderable
   {
     uses: TypedChainedMap<this, { [key: string]: Use }>;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -462,6 +462,45 @@ config.merge({
 });
 cssRule.merge({ use: { swc: { loader: 'builtin:swc-loader' } } });
 
+// All write paths must agree with the types returned by get().
+config.set('mode', 'development').merge({ mode: 'production' });
+swcUse.set('loader', undefined);
+const mode = config.getOrCompute('mode', () => 'development');
+expectTypeEqual<typeof mode, rspack.Configuration['mode']>();
+// @ts-expect-error mode cannot contain a number
+config.set('mode', 123);
+// @ts-expect-error merging cannot bypass the known key type
+config.merge({ mode: 123 });
+// @ts-expect-error computed values must match the known key type
+config.getOrCompute('mode', () => 123);
+// @ts-expect-error output keys are checked too
+config.output.set('filename', 123);
+// @ts-expect-error rule keys are checked too
+cssRule.merge({ resourceQuery: 123 });
+// @ts-expect-error loader values must be strings
+swcUse.getOrCompute('loader', () => 123);
+
+// Partial nested rules retain the chain merge format and validate known keys.
+config.merge({
+  entry: { main: ['./src/index.js'] },
+  output: { filename: '[name].js', customMetadata: true },
+  module: {
+    rule: {
+      css: {
+        oneOf: { inline: { use: { css: { options: { modules: true } } } } },
+      },
+    },
+  },
+  optimization: { minimizer: { custom: { plugin: rspack.DefinePlugin } } },
+});
+// @ts-expect-error nested loader writes cannot bypass validation
+config.merge({ module: { rule: { css: { use: { css: { loader: 123 } } } } } });
+// @ts-expect-error merging through module must validate child rules too
+config.module.merge({ rule: { css: { type: 123 } } });
+config.set('customMetadata', 123).merge({ customMetadata: false }, ['mode']);
+const customValue = config.getOrCompute('customMetadata', () => 123);
+expectTypeEqual<typeof customValue, any>();
+
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;
 


### PR DESCRIPTION
After #160, `get()` infers known configuration types, but unchecked writes such as `set('mode', 123)` can contradict those types. This PR validates known-key values in `set()`, `merge()`, and `getOrCompute()`, including nested rule and loader merges, while preserving custom keys and chain-specific merge structures.

Previously accepted values of the wrong type now produce TypeScript errors; runtime behavior is unchanged.

## Related Links

- [Review finding in #160](https://github.com/rstackjs/rspack-chain/pull/160#discussion_r3940736853)