### PR TITLE
fix(types): allow loose nested merge patches

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,16 @@ interface PluginInstance {
 }
 
 declare namespace __Config {
-  type MergeInput<OptionsType> = Partial<OptionsType> & Record<string, any>;
+  // Allow loose object patches and named child maps without recursive validation.
+  type MergeValue<Value> = Value extends Function | RegExp | Date
+    ? Value
+    : Value extends object
+      ? Value | Record<string, unknown>
+      : Value;
+
+  type MergeInput<OptionsType> = {
+    [Key in keyof OptionsType]?: MergeValue<OptionsType[Key]>;
+  } & Record<string, any>;
 
   class Chained<Parent> {
     batch(handler: (chained: this) => void): this;
@@ -38,11 +47,10 @@ declare namespace __Config {
     ): this;
   }
 
-  class ChainedMap<
+  class ChainedMap<Parent, OptionsType = any> extends TypedChainedMap<
     Parent,
-    OptionsType = any,
-    MergeOptions = OptionsType,
-  > extends TypedChainedMap<Parent, any> {
+    any
+  > {
     // Known keys share their read/write types; custom keys remain unrestricted.
     get<Key extends PropertyKey>(
       key: Key,
@@ -57,7 +65,7 @@ declare namespace __Config {
         ? () => OptionsType[Key] | undefined
         : () => any,
     ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
-    merge(obj: MergeInput<MergeOptions>, omit?: string[]): this;
+    merge(obj: MergeInput<OptionsType>, omit?: string[]): this;
   }
   class TypedChainedSet<Parent, Value> extends Chained<Parent> {
     add(value: Value): this;
@@ -80,8 +88,7 @@ declare namespace __Config {
 type RspackConfig = Required<Configuration>;
 export declare class RspackChain extends __Config.ChainedMap<
   void,
-  Configuration,
-  RspackChain.ConfigMergeOptions
+  Configuration
 > {
   entryPoints: RspackChain.TypedChainedMap<
     RspackChain,
@@ -143,11 +150,10 @@ export declare namespace RspackChain {
     Parent,
     OptionsType
   > {}
-  class ChainedMap<
+  class ChainedMap<Parent, OptionsType = any> extends __Config.ChainedMap<
     Parent,
-    OptionsType = any,
-    MergeOptions = OptionsType,
-  > extends __Config.ChainedMap<Parent, OptionsType, MergeOptions> {}
+    OptionsType
+  > {}
   class TypedChainedSet<Parent, Value> extends __Config.TypedChainedSet<
     Parent,
     Value
@@ -200,33 +206,7 @@ export declare namespace RspackChain {
 
   type RspackModule = Required<NonNullable<Configuration['module']>>;
 
-  // merge() accepts named child maps rather than the arrays in Rspack configs.
-  type RuleMergeOptions = Omit<RuleSetRule, 'use' | 'rules' | 'oneOf'> & {
-    use?: Record<string, __Config.MergeInput<RuleSetLoaderWithOptions>>;
-    rules?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
-    oneOf?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
-  };
-
-  type ModuleMergeOptions = NonNullable<Configuration['module']> & {
-    rule?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
-    defaultRule?: Record<string, __Config.MergeInput<RuleMergeOptions>>;
-  };
-
-  type ConfigMergeOptions = Omit<
-    Configuration,
-    'entry' | 'module' | 'optimization' | 'output'
-  > & {
-    entry?: Record<string, RspackEntryObject | RspackEntryObject[]>;
-    module?: __Config.MergeInput<ModuleMergeOptions>;
-    output?: __Config.MergeInput<NonNullable<Configuration['output']>>;
-    optimization?: __Config.MergeInput<
-      Omit<NonNullable<Configuration['optimization']>, 'minimizer'> & {
-        minimizer?: Record<string, any>;
-      }
-    >;
-  };
-
-  class Module extends ChainedMap<RspackChain, any, ModuleMergeOptions> {
+  class Module extends ChainedMap<RspackChain> {
     defaultRules: TypedChainedMap<this, { [key: string]: Rule }>;
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
     generator: ChainedMap<this>;
@@ -381,7 +361,7 @@ export declare namespace RspackChain {
   type RspackRuleSet = Required<RuleSetRule>;
 
   class Rule<T = Module>
-    extends ChainedMap<T, RuleSetRule, RuleMergeOptions>
+    extends ChainedMap<T, RuleSetRule>
     implements Orderable
   {
     uses: TypedChainedMap<this, { [key: string]: Use }>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,11 +20,11 @@ declare namespace __Config {
       ? Value | Record<string, unknown>
       : Value;
 
-  type MergeInput<OptionsType, NamedKeys extends keyof OptionsType = never> = {
-    [Key in keyof OptionsType]?: Key extends NamedKeys
-      ? OptionsType[Key] | Record<string, unknown>
-      : MergeValue<OptionsType[Key]>;
+  type MergeInput<OptionsType> = {
+    [Key in keyof OptionsType]?: MergeValue<OptionsType[Key]>;
   } & Record<string, any>;
+
+  type NamedPatches = Record<string, Record<string, any>>;
 
   class Chained<Parent> {
     batch(handler: (chained: this) => void): this;
@@ -50,10 +50,11 @@ declare namespace __Config {
     ): this;
   }
 
-  class ChainedMap<Parent, OptionsType = any> extends TypedChainedMap<
+  class ChainedMap<
     Parent,
-    any
-  > {
+    OptionsType = any,
+    MergeOverrides = unknown,
+  > extends TypedChainedMap<Parent, any> {
     // Known keys share their read/write types; custom keys remain unrestricted.
     get<Key extends PropertyKey>(
       key: Key,
@@ -68,7 +69,11 @@ declare namespace __Config {
         ? () => OptionsType[Key] | undefined
         : () => any,
     ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
-    merge(obj: MergeInput<OptionsType>, omit?: string[]): this;
+    // Apply chain-specific container types without loosening their shape.
+    merge(
+      obj: MergeInput<Omit<OptionsType, keyof MergeOverrides>> & MergeOverrides,
+      omit?: string[],
+    ): this;
   }
   class TypedChainedSet<Parent, Value> extends Chained<Parent> {
     add(value: Value): this;
@@ -91,7 +96,13 @@ declare namespace __Config {
 type RspackConfig = Required<Configuration>;
 export declare class RspackChain extends __Config.ChainedMap<
   void,
-  Configuration
+  Configuration,
+  {
+    entry?: Record<
+      string,
+      RspackChain.RspackEntryObject | RspackChain.RspackEntryObject[]
+    >;
+  }
 > {
   entryPoints: RspackChain.TypedChainedMap<
     RspackChain,
@@ -153,10 +164,11 @@ export declare namespace RspackChain {
     Parent,
     OptionsType
   > {}
-  class ChainedMap<Parent, OptionsType = any> extends __Config.ChainedMap<
+  class ChainedMap<
     Parent,
-    OptionsType
-  > {}
+    OptionsType = any,
+    MergeOverrides = unknown,
+  > extends __Config.ChainedMap<Parent, OptionsType, MergeOverrides> {}
   class TypedChainedSet<Parent, Value> extends __Config.TypedChainedSet<
     Parent,
     Value
@@ -211,7 +223,8 @@ export declare namespace RspackChain {
 
   class Module extends ChainedMap<
     RspackChain,
-    NonNullable<Configuration['module']>
+    NonNullable<Configuration['module']>,
+    { rule?: __Config.NamedPatches; defaultRule?: __Config.NamedPatches }
   > {
     defaultRules: TypedChainedMap<this, { [key: string]: Rule }>;
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
@@ -367,15 +380,17 @@ export declare namespace RspackChain {
   type RspackRuleSet = Required<RuleSetRule>;
 
   class Rule<T = Module>
-    extends ChainedMap<T, RuleSetRule>
+    extends ChainedMap<
+      T,
+      RuleSetRule,
+      {
+        use?: __Config.NamedPatches;
+        rules?: __Config.NamedPatches;
+        oneOf?: __Config.NamedPatches;
+      }
+    >
     implements Orderable
   {
-    // These child collections also accept named maps instead of arrays.
-    merge(
-      obj: __Config.MergeInput<RuleSetRule, 'use' | 'rules' | 'oneOf'>,
-      omit?: string[],
-    ): this;
-
     uses: TypedChainedMap<this, { [key: string]: Use }>;
     include: TypedChainedSet<this, RspackRuleSet['include']>;
     exclude: TypedChainedSet<this, RspackRuleSet['exclude']>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,15 +12,18 @@ interface PluginInstance {
 }
 
 declare namespace __Config {
-  // Allow loose object patches and named child maps without recursive validation.
-  type MergeValue<Value> = Value extends Function | RegExp | Date
+  // Allow loose object patches while preserving arrays and atomic values.
+  type MergeValue<Value> = Value extends
+    Function | readonly unknown[] | RegExp | Date
     ? Value
     : Value extends object
       ? Value | Record<string, unknown>
       : Value;
 
-  type MergeInput<OptionsType> = {
-    [Key in keyof OptionsType]?: MergeValue<OptionsType[Key]>;
+  type MergeInput<OptionsType, NamedKeys extends keyof OptionsType = never> = {
+    [Key in keyof OptionsType]?: Key extends NamedKeys
+      ? OptionsType[Key] | Record<string, unknown>
+      : MergeValue<OptionsType[Key]>;
   } & Record<string, any>;
 
   class Chained<Parent> {
@@ -206,7 +209,10 @@ export declare namespace RspackChain {
 
   type RspackModule = Required<NonNullable<Configuration['module']>>;
 
-  class Module extends ChainedMap<RspackChain> {
+  class Module extends ChainedMap<
+    RspackChain,
+    NonNullable<Configuration['module']>
+  > {
     defaultRules: TypedChainedMap<this, { [key: string]: Rule }>;
     rules: TypedChainedMap<this, { [key: string]: Rule }>;
     generator: ChainedMap<this>;
@@ -364,6 +370,12 @@ export declare namespace RspackChain {
     extends ChainedMap<T, RuleSetRule>
     implements Orderable
   {
+    // These child collections also accept named maps instead of arrays.
+    merge(
+      obj: __Config.MergeInput<RuleSetRule, 'use' | 'rules' | 'oneOf'>,
+      omit?: string[],
+    ): this;
+
     uses: TypedChainedMap<this, { [key: string]: Use }>;
     include: TypedChainedSet<this, RspackRuleSet['include']>;
     exclude: TypedChainedSet<this, RspackRuleSet['exclude']>;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -551,6 +551,12 @@ expectTypeEqual<typeof customValue, any>();
 // Partial object patches and named rule maps remain valid.
 config.output.merge({ library: { name: 'bar' } });
 cssRule.merge({ rules: { nested: {} }, oneOf: { inline: {} } });
+config.module.merge({ noParse: /vendor/, rule: { css: {} }, defaultRule: {} });
+config.output.merge({ enabledChunkLoadingTypes: ['jsonp'] });
+// @ts-expect-error known module fields must retain their types
+config.module.merge({ noParse: 123 });
+// @ts-expect-error ordinary array fields cannot be replaced with objects
+config.output.merge({ enabledChunkLoadingTypes: {} });
 // @ts-expect-error array elements must remain complete plugin instances
 config.merge({ plugins: [{}] });
 // @ts-expect-error filename callbacks must still return strings

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -534,7 +534,7 @@ swcUse.getOrCompute('loader', () => 123);
 // Nested merge objects stay loose to support partial patches and named maps.
 config.merge({
   entry: { main: ['./src/index.js'] },
-  output: { filename: '[name].js', customMetadata: true },
+  output: { library: { name: 'foo' }, customMetadata: true },
   module: {
     rule: {
       css: {
@@ -548,28 +548,13 @@ config.set('customMetadata', 123).merge({ customMetadata: false }, ['mode']);
 const customValue = config.getOrCompute('customMetadata', () => 123);
 expectTypeEqual<typeof customValue, any>();
 
-// Nested merge patches can update part of an existing object.
-config.module.merge({ rule: { css: { type: 'css' } } });
-cssRule.merge({
-  rules: { nested: { use: { css: { loader: 'css-loader' } } } },
-  oneOf: { inline: { resourceQuery: /inline/ } },
-});
-config.output.library({ type: 'var', name: 'foo' });
+// Partial object patches and named rule maps remain valid.
 config.output.merge({ library: { name: 'bar' } });
-config.merge({ output: { library: { name: 'baz' } } });
-config.output.merge({ filename: ({ filename }) => filename || '[name].js' });
-cssRule.merge({ resourceQuery: /inline/ });
-config.merge({ plugins: [new rspack.DefinePlugin({})] });
-
-// Array items, callbacks and replacement values retain their original types.
+cssRule.merge({ rules: { nested: {} }, oneOf: { inline: {} } });
 // @ts-expect-error array elements must remain complete plugin instances
 config.merge({ plugins: [{}] });
 // @ts-expect-error filename callbacks must still return strings
 config.output.merge({ filename: () => 123 });
-// @ts-expect-error set replaces the entire value rather than merging it
-config.output.set('library', { name: 'bar' });
-// @ts-expect-error computed values must also be complete
-config.output.getOrCompute('library', () => ({ name: 'bar' }));
 
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -562,6 +562,20 @@ config.merge({ plugins: [{}] });
 // @ts-expect-error filename callbacks must still return strings
 config.output.merge({ filename: () => 123 });
 
+// Chain merge containers require named maps with valid entry or object values.
+// @ts-expect-error entry shorthands are not supported by merge
+config.merge({ entry: './src/index.js' });
+// @ts-expect-error entry functions are not evaluated by merge
+config.merge({ entry: () => './src/index.js' });
+// @ts-expect-error use shorthands are not supported by merge
+cssRule.merge({ use: 'style-loader' });
+// @ts-expect-error use arrays containing strings are not supported by merge
+cssRule.merge({ use: ['style-loader'] });
+// @ts-expect-error rule patches must be objects
+config.module.merge({ rule: { css: 123 } });
+// @ts-expect-error default rule patches must be objects
+config.module.merge({ defaultRule: { css: 123 } });
+
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;
 

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -513,7 +513,7 @@ config.merge({
 });
 cssRule.merge({ use: { swc: { loader: 'builtin:swc-loader' } } });
 
-// All write paths must agree with the types returned by get().
+// Direct writes and top-level merge fields validate known key types.
 config.set('mode', 'development').merge({ mode: 'production' });
 swcUse.set('loader', undefined);
 const mode = config.getOrCompute('mode', () => 'development');
@@ -531,7 +531,7 @@ cssRule.merge({ resourceQuery: 123 });
 // @ts-expect-error loader values must be strings
 swcUse.getOrCompute('loader', () => 123);
 
-// Partial nested rules retain the chain merge format and validate known keys.
+// Nested merge objects stay loose to support partial patches and named maps.
 config.merge({
   entry: { main: ['./src/index.js'] },
   output: { filename: '[name].js', customMetadata: true },
@@ -544,13 +544,32 @@ config.merge({
   },
   optimization: { minimizer: { custom: { plugin: rspack.DefinePlugin } } },
 });
-// @ts-expect-error nested loader writes cannot bypass validation
-config.merge({ module: { rule: { css: { use: { css: { loader: 123 } } } } } });
-// @ts-expect-error merging through module must validate child rules too
-config.module.merge({ rule: { css: { type: 123 } } });
 config.set('customMetadata', 123).merge({ customMetadata: false }, ['mode']);
 const customValue = config.getOrCompute('customMetadata', () => 123);
 expectTypeEqual<typeof customValue, any>();
+
+// Nested merge patches can update part of an existing object.
+config.module.merge({ rule: { css: { type: 'css' } } });
+cssRule.merge({
+  rules: { nested: { use: { css: { loader: 'css-loader' } } } },
+  oneOf: { inline: { resourceQuery: /inline/ } },
+});
+config.output.library({ type: 'var', name: 'foo' });
+config.output.merge({ library: { name: 'bar' } });
+config.merge({ output: { library: { name: 'baz' } } });
+config.output.merge({ filename: ({ filename }) => filename || '[name].js' });
+cssRule.merge({ resourceQuery: /inline/ });
+config.merge({ plugins: [new rspack.DefinePlugin({})] });
+
+// Array items, callbacks and replacement values retain their original types.
+// @ts-expect-error array elements must remain complete plugin instances
+config.merge({ plugins: [{}] });
+// @ts-expect-error filename callbacks must still return strings
+config.output.merge({ filename: () => 123 });
+// @ts-expect-error set replaces the entire value rather than merging it
+config.output.set('library', { name: 'bar' });
+// @ts-expect-error computed values must also be complete
+config.output.getOrCompute('library', () => ({ name: 'bar' }));
 
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;


### PR DESCRIPTION
The stricter merge types introduced in #161 reject valid nested patches such as `output.merge({ library: { name: 'bar' } })` when the library type is already configured. This PR allows loose object patches without recursive field validation, while keeping chain-specific entry and child collections in their supported named-map form.

Top-level scalar fields, ordinary arrays, callbacks, and `set()` / `getOrCompute()` retain their type checks. Runtime behavior is unchanged.

## Related Links

- https://github.com/rstackjs/rspack-chain/pull/161