### PR TITLE
fix(types): validate named patches and allow partial overrides

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,7 @@ declare namespace __Config {
     [Key in keyof OptionsType]?: MergeValue<OptionsType[Key]>;
   } & Record<string, any>;
 
-  type NamedPatches = Record<string, Record<string, any>>;
+  type NamedPatches = Record<string, Record<string, unknown>>;
 
   class Chained<Parent> {
     batch(handler: (chained: this) => void): this;
@@ -71,7 +71,8 @@ declare namespace __Config {
     ): Key extends keyof OptionsType ? OptionsType[Key] | undefined : any;
     // Apply chain-specific container types without loosening their shape.
     merge(
-      obj: MergeInput<Omit<OptionsType, keyof MergeOverrides>> & MergeOverrides,
+      obj: MergeInput<Omit<OptionsType, keyof MergeOverrides>> &
+        Partial<MergeOverrides>,
       omit?: string[],
     ): this;
   }

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -576,20 +576,11 @@ config.module.merge({ rule: { css: 123 } });
 // @ts-expect-error default rule patches must be objects
 config.module.merge({ defaultRule: { css: 123 } });
 
-// Merge overrides describe optional patches, even when their fields are required.
-declare const customMap: RspackChain.ChainedMap<
-  void,
-  { value: string },
-  { value: string }
->;
-customMap.merge({});
-customMap.merge({ value: 'updated' });
+// Required override fields remain optional in merge patches.
+declare const map: RspackChain.ChainedMap<void, unknown, { value: string }>;
+map.merge({});
 // @ts-expect-error override values retain their declared types
-customMap.merge({ value: 123 });
-declare const typedRulePatch: rspack.RuleSetRule;
-declare const typedUsePatch: rspack.RuleSetLoaderWithOptions;
-config.module.merge({ rule: { css: typedRulePatch } });
-cssRule.merge({ use: { css: typedUsePatch } });
+map.merge({ value: 123 });
 // @ts-expect-error arrays are not named object patches
 cssRule.merge({ use: { css: [] } });
 // @ts-expect-error functions are not named object patches

--- a/types/test/rspack-chain-tests.ts
+++ b/types/test/rspack-chain-tests.ts
@@ -576,6 +576,27 @@ config.module.merge({ rule: { css: 123 } });
 // @ts-expect-error default rule patches must be objects
 config.module.merge({ defaultRule: { css: 123 } });
 
+// Merge overrides describe optional patches, even when their fields are required.
+declare const customMap: RspackChain.ChainedMap<
+  void,
+  { value: string },
+  { value: string }
+>;
+customMap.merge({});
+customMap.merge({ value: 'updated' });
+// @ts-expect-error override values retain their declared types
+customMap.merge({ value: 123 });
+declare const typedRulePatch: rspack.RuleSetRule;
+declare const typedUsePatch: rspack.RuleSetLoaderWithOptions;
+config.module.merge({ rule: { css: typedRulePatch } });
+cssRule.merge({ use: { css: typedUsePatch } });
+// @ts-expect-error arrays are not named object patches
+cssRule.merge({ use: { css: [] } });
+// @ts-expect-error functions are not named object patches
+cssRule.merge({ use: { css: () => {} } });
+// @ts-expect-error RegExp instances are not named object patches
+config.module.merge({ rule: { css: /css/ } });
+
 // Test TypedChainedMap
 const entryPoints = config.entryPoints;
 


### PR DESCRIPTION
Named merge patches currently accept arrays, functions, and RegExp instances, which can silently produce empty loader configurations. Require string-keyed object patches while keeping their fields loose, and make merge overrides optional so custom `ChainedMap` types continue to accept partial updates.

Runtime behavior is unchanged.

## Related Links

- [Named patch review in #162](https://github.com/rstackjs/rspack-chain/pull/162#discussion_r3942687578)
- [Previous merge type changes](https://github.com/rstackjs/rspack-chain/pull/162)